### PR TITLE
Always use light mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "invest-workbench",
   "productName": "invest-workbench",
   "version": "0.1.0-alpha",
-  "description": "My Electron application description",
+  "description": "Models that map and value the goods and services from nature that sustain and fulfill human life",
   "main": "src/main.js",
   "homepage": "./",
   "scripts": {

--- a/src/main.js
+++ b/src/main.js
@@ -10,7 +10,6 @@ if (isDevMode) {
 const {
   app, BrowserWindow, ipcMain, screen, nativeTheme
 } = require('electron'); // eslint-disable-line import/no-extraneous-dependencies
-//    const { nativeTheme } = require("electron").remote;
 const {
   getFlaskIsReady, shutdownPythonProcess
 } = require('./server_requests');

--- a/src/main.js
+++ b/src/main.js
@@ -8,8 +8,9 @@ if (isDevMode) {
 }
 
 const {
-  app, BrowserWindow, ipcMain, screen
+  app, BrowserWindow, ipcMain, screen, nativeTheme
 } = require('electron'); // eslint-disable-line import/no-extraneous-dependencies
+//    const { nativeTheme } = require("electron").remote;
 const {
   getFlaskIsReady, shutdownPythonProcess
 } = require('./server_requests');
@@ -39,6 +40,10 @@ const createWindow = async () => {
   createPythonFlaskProcess(binaries.server, isDevMode);
   // Wait for a response from the server before loading the app
   await getFlaskIsReady();
+
+  // always use light mode regardless of the OS/browser setting
+  // in the future we can add a dark theme
+  nativeTheme.themeSource = 'light';
 
   // Create the browser window.
   const { width, height } = screen.getPrimaryDisplay().workAreaSize;


### PR DESCRIPTION
Fixes #58 
Override OS dark/light mode setting to always use light mode, until we get around to making a dark theme.
Also filled in the package.json description (copied from the invest repo)