### PR TITLE
Fix SettingsModal console error

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
   "jest": {
     "verbose": true,
     "collectCoverage": true,
-    "testEnvironment": "jest-environment-jsdom-sixteen"
+    "testEnvironment": "jest-environment-jsdom-sixteen",
+    "setupFiles": ["./tests/jest.overrides.js"]
   },
   "invest": {
     "version": "3.8.7"

--- a/src/components/SettingsModal/index.jsx
+++ b/src/components/SettingsModal/index.jsx
@@ -13,7 +13,10 @@ export default class SettingsModal extends React.Component {
     super(props);
     this.state = {
       show: false,
-      localSettings: {}
+      localSettings: {
+        nWorkers: '',
+        loggingLevel: ''
+      }
     };
 
     this.handleShow = this.handleShow.bind(this);

--- a/tests/jest.overrides.js
+++ b/tests/jest.overrides.js
@@ -1,0 +1,8 @@
+// Cause tests to fail on console.error messages
+// Taken from https://stackoverflow.com/questions/28615293/is-there-a-jest-config-that-will-fail-tests-on-console-warn/50584643#50584643
+let error = console.error
+
+console.error = function (message) {
+  error.apply(console, arguments) // keep default behaviour
+  throw (message instanceof Error ? message : new Error(message))
+}


### PR DESCRIPTION
Fixes #55 
The `Warning: A component is changing an uncontrolled input of type text to be controlled` can happen when `setState` adds properties to the state. We should avoid it by making sure that all state properties that will ever be set are declared in the constructor.

The `<Form.Control>` that the error originates from is inside of a `<Modal>` and the error only appears in the test, not when using the app. However, taking it out of the `<Modal>` causes the error to show up when you start the app as well. This is kind of concerning... either the `<Modal>` is suppressing the error somehow, or the DOM being tested is different from that when you use the app?

I also added a jest config that causes tests to fail on `console.error` messages. I couldn't find any information about getting a more helpful traceback; other error tracebacks do have line numbers so maybe this is just an unusual situation.
