### PR TITLE
Code-signing with electron-builder

### DIFF
--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -130,16 +130,14 @@ jobs:
 
       run: |
         set +x
-        
-        # download the p12 certificate file from google cloud
+
         gsutil cp gs://stanford_cert/$P12_FILE ~/$P12_FILE
 
         security list-keychains
-        # create a new keychain (so that we can know what the password is)
         security create-keychain -p $KEYCHAIN_PASS $KEYCHAIN_NAME
-        # add the keychain to the search list so it can be found
         security list-keychains -s $KEYCHAIN_NAME
         security list-keychains
+        
         # # unlock the keychain so we can import to it (stays unlocked 5 minutes by default)
         # security unlock-keychain -p $KEYCHAIN_PASS $KEYCHAIN_NAME
         # # add the certificate to the keychain

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -131,15 +131,13 @@ jobs:
       run: |
         gsutil cp gs://stanford_cert/Stanford-natcap-code-signing-2019-03-07.p12 $P12_FILE_PATH 
 
-        pwd
-
         bash ./scripts/setup_macos_keychain.sh 
 
         # these env variables tell electron-builder to do code signing
         echo "CSC_KEYCHAIN=$KEYCHAIN_NAME" >> $GITHUB_ENV
         echo "CSC_NAME='Stanford University'" >> $GITHUB_ENV
         echo "CSC_KEY_PASSWORD=${{ secrets.CERT_KEY_PASS }}" >> $GITHUB_ENV
-        #echo "CSC_IDENTITY_AUTO_DISCOVERY=false" >> $GITHUB_ENV
+        echo "CSC_IDENTITY_AUTO_DISCOVERY=false" >> $GITHUB_ENV
        
 
     - name: Code-signing setup for Windows
@@ -158,12 +156,14 @@ jobs:
       if: matrix.os == 'macos-latest'
       env:
         GH_TOKEN: env.GITHUB_TOKEN
+        DEBUG: electron-builder
       run: npx --no-install electron-builder build --mac -c.extraMetadata.main=build/main.js --publish never
 
     - name: Run electron-builder on windows
       if: matrix.os == 'windows-latest'
       env:
         GH_TOKEN: env.GITHUB_TOKEN
+        DEBUG: electron-builder
       run: npx --no-install electron-builder build --windows -c.extraMetadata.main=build/main.js --publish never
 
     - name: Run electron-builder on ubuntu

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -25,6 +25,10 @@ jobs:
       shell: bash
       run: echo "{INVEST_VERSION}={$(jq -r .invest.version package.json)}" >> $GITHUB_ENV
 
+    - name: test env var
+      shell: bash
+      run: echo $INVEST_VERSION
+
     - name: Clone natcap/invest
       uses: actions/checkout@v2
       with:

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -116,19 +116,19 @@ jobs:
       if: matrix.os == 'macos-latest'
       env:
         GH_TOKEN: env.GITHUB_TOKEN
-      run: npx --no-install electron-builder build --mac -c.extraMetadata.foo=bar
+      run: npx --no-install electron-builder build --mac -c.extraMetadata.main=build/main.js
 
     - name: Run electron-builder on windows
       if: matrix.os == 'windows-latest'
       env:
         GH_TOKEN: env.GITHUB_TOKEN
-      run: npx --no-install electron-builder build --windows -c.extraMetadata.foo=bar
+      run: npx --no-install electron-builder build --windows -c.extraMetadata.main=build/main.js
 
     - name: Run electron-builder on ubuntu
       if: matrix.os == 'ubuntu-latest'
       env:
         GH_TOKEN: env.GITHUB_TOKEN
-      run: npx --no-install electron-builder build --linux -c.extraMetadata.foo=bar
+      run: npx --no-install electron-builder build --linux -c.extraMetadata.main=build/main.js
 
       # Also run all tests on the build dir code?
     - name: Test flask app binaries

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -2,6 +2,10 @@ name: Build, Test Binaries, & Release
 
 on: [push, pull_request]
 
+defaults:
+  run:
+    shell: bash -l {0}
+
 jobs:
   build-and-release:
     runs-on: ${{ matrix.os }}
@@ -21,8 +25,7 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
 
-    - name: Set env var
-      shell: bash
+    - name: Set env var for invest version
       run: |
         INVEST_VERSION=$(jq -r .invest.version package.json)
         echo "INVEST_VERSION=$INVEST_VERSION" >> $GITHUB_ENV
@@ -50,7 +53,6 @@ jobs:
 
     - name: Install python dependencies for non-Windows
       if: matrix.os != 'windows-latest'
-      shell: bash -l {0}
       working-directory: ./invest
       run: |
           conda upgrade -y pip setuptools
@@ -77,7 +79,6 @@ jobs:
     - name: Install python build dependencies for Windows
       if: matrix.os == 'windows-latest'
       working-directory: ./invest
-      shell: bash -l {0}
       run: |
           python -m pip install --upgrade pip nose setuptools toml twine ${{ matrix.numpy }}
           pip install $(python -c "import toml;print(' '.join(toml.load('pyproject.toml')['build-system']['requires']))")
@@ -85,7 +86,6 @@ jobs:
     - name: Install python runtime dependencies for Windows
       if: matrix.os == 'windows-latest'
       working-directory: ./invest
-      shell: bash -l {0}
       env:
         PIP_EXTRA_INDEX_URL: "http://pypi.naturalcapitalproject.org/simple/"
         PIP_TRUSTED_HOST: "pypi.naturalcapitalproject.org"
@@ -97,21 +97,17 @@ jobs:
         cp ${{ env.SITE_PACKAGES }}/shapely/DLLs/geos_c.dll ${{ env.SITE_PACKAGES }}/shapely/DLLs/geos.dll
     
     - name: Install natcap.invest python package
-      shell: bash -l {0}
       working-directory: ./invest
       run: make install
 
     - name: Freeze Python environment
-      shell: bash -l {0}
       run: |
         python -m PyInstaller --workpath build/pyi-build --clean --distpath build ./invest-flask.spec
 
     - name: NPM Install
-      shell: bash -l {0} 
       run: npm install
 
     - name: Run the build script
-      shell: bash -l {0} 
       run: npm run build
 
     - name: Set up GCP
@@ -125,7 +121,6 @@ jobs:
     # electron-builder code signing only supported on macos and windows
     - name: Code-signing for macOS
       if: matrix.os == 'macos-latest'
-      shell: bash -l {0}
       env:
         P12_FILE: Stanford-natcap-code-signing-2019-03-07.p12
         KEYCHAIN_NAME: codesign_keychain
@@ -158,7 +153,6 @@ jobs:
 
     - name: Code-signing for Windows
       if: matrix.os == 'windows-latest'
-      shell: bash -l {0} 
       env:
         P12_FILE: Stanford-natcap-code-signing-2019-03-07.p12
       run: |
@@ -171,28 +165,24 @@ jobs:
 
     - name: Run electron-builder on macOS
       if: matrix.os == 'macos-latest'
-      shell: bash -l {0}
       env:
         GH_TOKEN: env.GITHUB_TOKEN
       run: npx --no-install electron-builder build --mac -c.extraMetadata.main=build/main.js --publish never
 
     - name: Run electron-builder on windows
       if: matrix.os == 'windows-latest'
-      shell: bash -l {0} 
       env:
         GH_TOKEN: env.GITHUB_TOKEN
       run: npx --no-install electron-builder build --windows -c.extraMetadata.main=build/main.js --publish never
 
     - name: Run electron-builder on ubuntu
       if: matrix.os == 'ubuntu-latest'
-      shell: bash -l {0} 
       env:
         GH_TOKEN: env.GITHUB_TOKEN
       run: npx --no-install electron-builder build --linux -c.extraMetadata.main=build/main.js --publish never
 
       # Also run all tests on the build dir code?
     - name: Test flask app binaries
-      shell: bash -l {0}
       run: npm run test-flask-app
 
     - name: Test electron app with puppeteer

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -131,17 +131,17 @@ jobs:
         # download the p12 certificate file from google cloud
         gsutil cp gs://stanford_cert/$P12_FILE ~/$P12_FILE
         # create a new keychain (so that we can know what the password is)
-        security create-keychain -p '$(KEYCHAIN_PASS)' '$(KEYCHAIN_NAME)'
+        security create-keychain -p $KEYCHAIN_PASS $KEYCHAIN_NAME
         # add the keychain to the search list so it can be found
-        security list-keychains -s '$(KEYCHAIN_NAME)'
+        security list-keychains -s $KEYCHAIN_NAME
         # unlock the keychain so we can import to it (stays unlocked 5 minutes by default)
-        security unlock-keychain -p '$(KEYCHAIN_PASS)' '$(KEYCHAIN_NAME)'
+        security unlock-keychain -p $KEYCHAIN_PASS $KEYCHAIN_NAME
         # add the certificate to the keychain
         # -T option says that the codesign executable can access the keychain
         # for some reason this alone is not enough, also need the following step
-        security import $(BUILD_DIR)/$(P12_FILE) -k '$(KEYCHAIN_NAME)' -P '$(CERT_KEY_PASS)' -T /usr/bin/codesign
+        security import $BUILD_DIR/$P12_FILE -k $KEYCHAIN_NAME -P $CERT_KEY_PASS -T /usr/bin/codesign
         # this is essential to avoid the UI password prompt
-        security set-key-partition-list -S apple-tool:,apple: -s -k '$(KEYCHAIN_PASS)' '$(KEYCHAIN_NAME)'
+        security set-key-partition-list -S apple-tool:,apple: -s -k $KEYCHAIN_PASS $KEYCHAIN_NAME
 
         # these env variables tell electron-builder to do code signing
         echo "CSC_KEYCHAIN=$KEYCHAIN_NAME" >> $GITHUB_ENV

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -120,7 +120,7 @@ jobs:
       if: matrix.os == 'windows-latest'
       env:
         GH_TOKEN: env.GITHUB_TOKEN
-      run: npx --no-install electron-builder --windows -c.extraMetadata.main=build/main.js
+      run: npx --no-install electron-builder --windows -c.extraMetadata.main=build\main.js
 
     - name: Run electron-builder on ubuntu
       if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -122,13 +122,13 @@ jobs:
       if: matrix.os == 'windows-latest'
       env:
         GH_TOKEN: env.GITHUB_TOKEN
-      run: npx --no-install electron-builder --windows -c.extraMetadata.foo=
+      run: npx --no-install electron-builder --windows -c.extraMetadata.foo=bar
 
     - name: Run electron-builder on ubuntu
       if: matrix.os == 'ubuntu-latest'
       env:
         GH_TOKEN: env.GITHUB_TOKEN
-      run: npx --no-install electron-builder --linux -c.extraMetadata.main=build/main.js
+      run: npx --no-install electron-builder --linux -c.extraMetadata.foo=bar
 
       # Also run all tests on the build dir code?
     - name: Test flask app binaries

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -112,15 +112,15 @@ jobs:
 
     - name: Run electron-builder on macOS
       if: matrix.os == 'macos-latest'
-      run: npx --no-install electron-builder --mac ${args}
+      run: npx --no-install electron-builder --mac -c.extraMetadata.main=build/main.js
 
     - name: Run electron-builder on windows
       if: matrix.os == 'windows-latest'
-      run: npx --no-install electron-builder --windows ${args}
+      run: npx --no-install electron-builder --windows -c.extraMetadata.main=build/main.js
 
     - name: Run electron-builder on ubuntu
       if: matrix.os == 'ubuntu-latest'
-      run: npx --no-install electron-builder --linux ${args}
+      run: npx --no-install electron-builder --linux -c.extraMetadata.main=build/main.js
 
     - name: Build & Release Electron application
       uses: samuelmeuli/action-electron-builder@v1

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -23,7 +23,7 @@ jobs:
     
     - name: Set env var for invest version
       shell: bash
-      run: echo ::set-env name=INVEST_VERSION::$(jq -r .invest.version package.json)
+      run: echo "{INVEST_VERSION}={$(jq -r .invest.version package.json)}" >> $GITHUB_ENV
 
     - name: Clone natcap/invest
       uses: actions/checkout@v2
@@ -114,13 +114,13 @@ jobs:
       if: matrix.os == 'macos-latest'
       env:
         GH_TOKEN: env.GITHUB_TOKEN
-      run: npx --no-install electron-builder --mac -c.extraMetadata.main=build/main.js
+      run: npx --no-install electron-builder --mac -c.extraMetadata.foo=bar
 
     - name: Run electron-builder on windows
       if: matrix.os == 'windows-latest'
       env:
         GH_TOKEN: env.GITHUB_TOKEN
-      run: npx --no-install electron-builder --windows -c.extraMetadata.main=build\main.js
+      run: npx --no-install electron-builder --windows -c.extraMetadata.foo=
 
     - name: Run electron-builder on ubuntu
       if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -25,15 +25,7 @@ jobs:
       shell: bash
       run: |
         INVEST_VERSION=$(jq -r .invest.version package.json)
-        echo $INVEST_VERSION
-        echo "INVEST_VERSION=$INVEST_VERSION"
         echo "INVEST_VERSION=$INVEST_VERSION" >> $GITHUB_ENV
-
-    - name: test env var
-      shell: bash
-      env:
-        INVEST_VERSION: 
-      run: echo "${{ env.INVEST_VERSION }}"
 
     - name: Clone natcap/invest
       uses: actions/checkout@v2

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -133,7 +133,8 @@ jobs:
 
         pwd
         echo $P12_FILE_PATH
-        CERT_KEY_PASS=fake-pass
+        CERT_KEY_PASS=fake-cert-pass
+        KEYCHAIN_PASS=fake-keychain-pass
         bash ./scripts/setup_macos_keychain.sh $KEYCHAIN_NAME $KEYCHAIN_PASS $CERT_KEY_PASS $P12_FILE_PATH 
 
         # these env variables tell electron-builder to do code signing

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -122,20 +122,51 @@ jobs:
           version: '281.0.0'
           service_account_key: ${{ secrets.GOOGLE_SERVICE_ACC_KEY }}
 
-    - name: Download code-signing certificate, set env vars
-      # electron-builder code signing only supported on macos and windows
-      if: matrix.os == 'macos-latest' || matrix.os == 'windows-latest'
-      shell: bash -l {0} 
+    # electron-builder code signing only supported on macos and windows
+    - name: Code-signing for macOS
+      if: matrix.os == 'macos-latest'
+      shell: bash -l {0}
+      env:
+        P12_FILE: Stanford-natcap-code-signing-2019-03-07.p12
+        KEYCHAIN_NAME: codesign_keychain
+        KEYCHAIN_PASS: ${{ secrets.KEYCHAIN_PASS }}
+        CERT_KEY_PASS: ${{ secrets.STANFORD_CERT_KEY_PASS }}
+
       run: |
-        P12_FILE=Stanford-natcap-code-signing-2019-03-07.p12
-        CERTIFICATE_PATH=~/Downloads/$P12_FILE
-        gsutil cp gs://stanford_cert/$P12_FILE $CERTIFICATE_PATH
+        # download the p12 certificate file from google cloud
+        gsutil cp gs://stanford_cert/$P12_FILE ~/$P12_FILE
+        # create a new keychain (so that we can know what the password is)
+        security create-keychain -p '$(KEYCHAIN_PASS)' '$(KEYCHAIN_NAME)'
+        # add the keychain to the search list so it can be found
+        security list-keychains -s '$(KEYCHAIN_NAME)'
+        # unlock the keychain so we can import to it (stays unlocked 5 minutes by default)
+        security unlock-keychain -p '$(KEYCHAIN_PASS)' '$(KEYCHAIN_NAME)'
+        # add the certificate to the keychain
+        # -T option says that the codesign executable can access the keychain
+        # for some reason this alone is not enough, also need the following step
+        security import $(BUILD_DIR)/$(P12_FILE) -k '$(KEYCHAIN_NAME)' -P '$(CERT_KEY_PASS)' -T /usr/bin/codesign
+        # this is essential to avoid the UI password prompt
+        security set-key-partition-list -S apple-tool:,apple: -s -k '$(KEYCHAIN_PASS)' '$(KEYCHAIN_NAME)'
+
+        # these env variables tell electron-builder to do code signing
+        echo "CSC_KEYCHAIN=$KEYCHAIN_NAME" >> $GITHUB_ENV
+        echo "CSC_NAME='Stanford University'" >> $GITHUB_ENV
+        echo "CSC_IDENTITY_AUTO_DISCOVERY=false" >> $GITHUB_ENV
+
+        # echo "CSC_KEY_PASSWORD=${{ secrets.CERT_KEY_PASS }}" >> $GITHUB_ENV
+       
+
+    - name: Code-signing for Windows
+      if: matrix.os == 'windows-latest'
+      shell: bash -l {0} 
+      env:
+        P12_FILE: Stanford-natcap-code-signing-2019-03-07.p12
+      run: |
+        gsutil cp gs://stanford_cert/$P12_FILE ~/$P12_FILE
 
         # all these variables are used by electron-builder
-        echo "GH_TOKEN=${{ env.GITHUB_TOKEN }}" >> $GITHUB_ENV
         echo "CSC_LINK=$CERTIFICATE_PATH" >> $GITHUB_ENV
         echo "CSC_KEY_PASSWORD=${{ secrets.CERT_KEY_PASS }}" >> $GITHUB_ENV
-        # echo "CSC_NAME='Stanford University'" >> $GITHUB_ENV
         echo "CSC_IDENTITY_AUTO_DISCOVERY=false" >> $GITHUB_ENV
 
     - name: Run electron-builder on macOS

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -27,7 +27,7 @@ jobs:
 
     - name: test env var
       shell: bash
-      run: echo $INVEST_VERSION
+      run: echo ${{ env.INVEST_VERSION }}
 
     - name: Clone natcap/invest
       uses: actions/checkout@v2

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -23,11 +23,11 @@ jobs:
 
     - name: Set env var
       shell: bash
-      run:
+      run: |
         INVEST_VERSION=$(jq -r .invest.version package.json)
         echo $INVEST_VERSION
         echo "INVEST_VERSION=$INVEST_VERSION"
-        echo "action_state=$INVEST_VERSION" >> $GITHUB_ENV
+        echo "INVEST_VERSION=$INVEST_VERSION" >> $GITHUB_ENV
 
     - name: test env var
       shell: bash

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -121,6 +121,7 @@ jobs:
     # electron-builder code signing only supported on macos and windows
     - name: Code-signing for macOS
       if: matrix.os == 'macos-latest'
+      shell: bash
       env:
         P12_FILE: Stanford-natcap-code-signing-2019-03-07.p12
         KEYCHAIN_NAME: codesign_keychain
@@ -130,10 +131,12 @@ jobs:
       run: |
         # download the p12 certificate file from google cloud
         gsutil cp gs://stanford_cert/$P12_FILE ~/$P12_FILE
+        security list-keychains
         # create a new keychain (so that we can know what the password is)
         security create-keychain -p $KEYCHAIN_PASS $KEYCHAIN_NAME
         # add the keychain to the search list so it can be found
         security list-keychains -s $KEYCHAIN_NAME
+        security list-keychains
         # unlock the keychain so we can import to it (stays unlocked 5 minutes by default)
         security unlock-keychain -p $KEYCHAIN_PASS $KEYCHAIN_NAME
         # add the certificate to the keychain

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -29,11 +29,15 @@ jobs:
 
     - name: test env var
       shell: bash
+      env:
+          INVEST_VERSION: jq -r .invest.version package.json
       run: echo ${{ env.INVEST_VERSION }}
 
     - name: Clone natcap/invest
       uses: actions/checkout@v2
       with:
+        env:
+          INVEST_VERSION: jq -r .invest.version package.json
         repository: natcap/invest
         ref: refs/tags/${{env.INVEST_VERSION}}
         path: ./invest

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -33,7 +33,7 @@ jobs:
         INVEST_VERSION: $(jq -r .invest.version package.json)
       with:
         repository: natcap/invest
-        ref: refs/tags/${{ env.INVEST_VERSION }}
+        ref: "refs/tags/${{ env.INVEST_VERSION }}"
         path: ./invest
 
     - name: Install libspatialindex for ubuntu

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -35,9 +35,9 @@ jobs:
 
     - name: Clone natcap/invest
       uses: actions/checkout@v2
+      env:
+        INVEST_VERSION: jq -r .invest.version package.json
       with:
-        env:
-          INVEST_VERSION: jq -r .invest.version package.json
         repository: natcap/invest
         ref: refs/tags/${{env.INVEST_VERSION}}
         path: ./invest

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -116,19 +116,19 @@ jobs:
       if: matrix.os == 'macos-latest'
       env:
         GH_TOKEN: env.GITHUB_TOKEN
-      run: npx --no-install electron-builder --mac -c.extraMetadata.foo=bar
+      run: npx --no-install electron-builder build --mac -c.extraMetadata.foo=bar
 
     - name: Run electron-builder on windows
       if: matrix.os == 'windows-latest'
       env:
         GH_TOKEN: env.GITHUB_TOKEN
-      run: npx --no-install electron-builder --windows -c.extraMetadata.foo=bar
+      run: npx --no-install electron-builder build --windows -c.extraMetadata.foo=bar
 
     - name: Run electron-builder on ubuntu
       if: matrix.os == 'ubuntu-latest'
       env:
         GH_TOKEN: env.GITHUB_TOKEN
-      run: npx --no-install electron-builder --linux -c.extraMetadata.foo=bar
+      run: npx --no-install electron-builder build --linux -c.extraMetadata.foo=bar
 
       # Also run all tests on the build dir code?
     - name: Test flask app binaries

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -20,12 +20,6 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    
-    - name: Set env var for invest version
-      shell: bash
-      run: |
-        jq -r .invest.version package.json
-        # echo "{INVEST_VERSION}={$(jq -r .invest.version package.json)}" >> $GITHUB_ENV
 
     - name: test env var
       shell: bash
@@ -39,7 +33,7 @@ jobs:
         INVEST_VERSION: $(jq -r .invest.version package.json)
       with:
         repository: natcap/invest
-        ref: refs/tags/${{env.INVEST_VERSION}}
+        ref: refs/tags/${{ env.INVEST_VERSION }}
         path: ./invest
 
     - name: Install libspatialindex for ubuntu

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -107,14 +107,17 @@ jobs:
         python -m PyInstaller --workpath build/pyi-build --clean --distpath build ./invest-flask.spec
 
     - name: NPM Install
+      shell: bash -l {0} 
       run: npm install
 
     - name: Run the build script
+      shell: bash -l {0} 
       run: npm run build
 
     - name: Set up GCP
       # Secrets not available in PR so don't use GCP.
       if: github.event_name != 'pull_request'
+      shell: bash -l {0} 
       uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
       with:
           version: '281.0.0'
@@ -122,7 +125,8 @@ jobs:
 
     - name: Download code-signing certificate, set env vars
       # electron-builder code signing only supported on macos and windows
-      if: matrix.os == 'macos-latest' || matrix.os == 'windows-latest' 
+      if: matrix.os == 'macos-latest' || matrix.os == 'windows-latest'
+      shell: bash -l {0} 
       run: |
         P12_FILE=Stanford-natcap-code-signing-2019-03-07.p12
         CERTIFICATE_PATH=~/Downloads/$P12_FILE
@@ -137,18 +141,21 @@ jobs:
 
     - name: Run electron-builder on macOS
       if: matrix.os == 'macos-latest'
+      shell: bash -l {0}
       env:
         GH_TOKEN: env.GITHUB_TOKEN
       run: npx --no-install electron-builder build --mac -c.extraMetadata.main=build/main.js --publish never
 
     - name: Run electron-builder on windows
       if: matrix.os == 'windows-latest'
+      shell: bash -l {0} 
       env:
         GH_TOKEN: env.GITHUB_TOKEN
       run: npx --no-install electron-builder build --windows -c.extraMetadata.main=build/main.js --publish never
 
     - name: Run electron-builder on ubuntu
       if: matrix.os == 'ubuntu-latest'
+      shell: bash -l {0} 
       env:
         GH_TOKEN: env.GITHUB_TOKEN
       run: npx --no-install electron-builder build --linux -c.extraMetadata.main=build/main.js --publish never

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -23,7 +23,9 @@ jobs:
     
     - name: Set env var for invest version
       shell: bash
-      run: echo "{INVEST_VERSION}={$(jq -r .invest.version package.json)}" >> $GITHUB_ENV
+      run: 
+        jq -r .invest.version package.json
+        echo "{INVEST_VERSION}={$(jq -r .invest.version package.json)}" >> $GITHUB_ENV
 
     - name: test env var
       shell: bash

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -136,7 +136,7 @@ jobs:
         echo "CSC_LINK=$CERTIFICATE_PATH" >> $GITHUB_ENV
         echo "CSC_KEY_PASSWORD=${{ secrets.CERT_KEY_PASS }}" >> $GITHUB_ENV
         echo "CSC_NAME='Stanford University'" >> $GITHUB_ENV
-        # echo "CSC_IDENTITY_AUTO_DISCOVERY=false" >> $GITHUB_ENV
+        echo "CSC_IDENTITY_AUTO_DISCOVERY=false" >> $GITHUB_ENV
 
     - name: Run electron-builder on macOS
       if: matrix.os == 'macos-latest'

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -132,10 +132,8 @@ jobs:
         gsutil cp gs://stanford_cert/Stanford-natcap-code-signing-2019-03-07.p12 $P12_FILE_PATH 
 
         pwd
-        echo $P12_FILE_PATH
-        CERT_KEY_PASS=fake-cert-pass
-        KEYCHAIN_PASS=fake-keychain-pass
-        bash ./scripts/setup_macos_keychain.sh $KEYCHAIN_NAME $KEYCHAIN_PASS $CERT_KEY_PASS $P12_FILE_PATH 
+
+        bash ./scripts/setup_macos_keychain.sh 
 
         # these env variables tell electron-builder to do code signing
         echo "CSC_KEYCHAIN=$KEYCHAIN_NAME" >> $GITHUB_ENV

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -141,7 +141,7 @@ jobs:
         run: npm run test-electron-app
     
     - name: Upload installer artifacts
-      uses: actions/upload-artifact@v2-preview
+      uses: actions/upload-artifact@v2.2.1
       if: ${{ always() }}
       with:
         name: invest-workbench-${{ matrix.os }}

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -137,7 +137,7 @@ jobs:
         echo "CSC_LINK=$CERTIFICATE_PATH" >> $GITHUB_ENV
         echo "CSC_KEY_PASSWORD=${{ secrets.CERT_KEY_PASS }}" >> $GITHUB_ENV
         echo "CSC_NAME='Stanford University'" >> $GITHUB_ENV
-        echo "CSC_IDENTITY_AUTO_DISCOVERY=false" >> $GITHUB_ENV
+        # echo "CSC_IDENTITY_AUTO_DISCOVERY=false" >> $GITHUB_ENV
 
     - name: Run electron-builder on macOS
       if: matrix.os == 'macos-latest'

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -138,9 +138,8 @@ jobs:
         # these env variables tell electron-builder to do code signing
         echo "CSC_KEYCHAIN=$KEYCHAIN_NAME" >> $GITHUB_ENV
         echo "CSC_NAME='Stanford University'" >> $GITHUB_ENV
-        echo "CSC_IDENTITY_AUTO_DISCOVERY=false" >> $GITHUB_ENV
-
-        # echo "CSC_KEY_PASSWORD=${{ secrets.CERT_KEY_PASS }}" >> $GITHUB_ENV
+        echo "CSC_KEY_PASSWORD=${{ secrets.CERT_KEY_PASS }}" >> $GITHUB_ENV
+        #echo "CSC_IDENTITY_AUTO_DISCOVERY=false" >> $GITHUB_ENV
        
 
     - name: Code-signing setup for Windows

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -113,7 +113,7 @@ jobs:
     - name: Set up GCP
       # Secrets not available in PR so don't use GCP.
       if: github.event_name != 'pull_request'
-      uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+      uses: google-github-actions/setup-gcloud@v0.2.0
       with:
           version: '281.0.0'
           service_account_key: ${{ secrets.GOOGLE_SERVICE_ACC_KEY }}
@@ -137,6 +137,10 @@ jobs:
         security create-keychain -p fake-password fake-keychain
         security list-keychains -s fake-keychain
         security list-keychains
+        echo $KEYCHAIN_NAME
+        echo '$KEYCHAIN_NAME'
+        echo $(KEYCHAIN_NAME)
+        echo '$(KEYCHAIN_NAME)'
         # security create-keychain -p $KEYCHAIN_PASS $KEYCHAIN_NAME
         # security list-keychains -s $KEYCHAIN_NAME
         # security list-keychains
@@ -166,7 +170,7 @@ jobs:
         gsutil cp gs://stanford_cert/$P12_FILE ~/$P12_FILE
 
         # all these variables are used by electron-builder
-        echo "CSC_LINK=$CERTIFICATE_PATH" >> $GITHUB_ENV
+        echo "CSC_LINK=~/$P12_FILE >> $GITHUB_ENV
         echo "CSC_KEY_PASSWORD=${{ secrets.CERT_KEY_PASS }}" >> $GITHUB_ENV
         echo "CSC_IDENTITY_AUTO_DISCOVERY=false" >> $GITHUB_ENV
 

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -133,17 +133,14 @@ jobs:
 
         gsutil cp gs://stanford_cert/$P12_FILE ~/$P12_FILE
 
-        security list-keychains
-        security create-keychain -p fake-password fake-keychain
-        security list-keychains -s fake-keychain
-        security list-keychains
+        KEYCHAIN_NAME=fake-keychain
+        KEYCHAIN_PASS=fake-password
         echo $KEYCHAIN_NAME
-        echo '$KEYCHAIN_NAME'
-        echo $(KEYCHAIN_NAME)
-        echo '$(KEYCHAIN_NAME)'
-        # security create-keychain -p $KEYCHAIN_PASS $KEYCHAIN_NAME
-        # security list-keychains -s $KEYCHAIN_NAME
-        # security list-keychains
+        echo $KEYCHAIN_PASS
+        security list-keychains
+        security create-keychain -p $KEYCHAIN_PASS $KEYCHAIN_NAME
+        security list-keychains -s $KEYCHAIN_NAME
+        security list-keychains
 
         # # unlock the keychain so we can import to it (stays unlocked 5 minutes by default)
         # security unlock-keychain -p $KEYCHAIN_PASS $KEYCHAIN_NAME
@@ -170,7 +167,7 @@ jobs:
         gsutil cp gs://stanford_cert/$P12_FILE ~/$P12_FILE
 
         # all these variables are used by electron-builder
-        echo "CSC_LINK=~/$P12_FILE >> $GITHUB_ENV
+        echo "CSC_LINK=~/$P12_FILE" >> $GITHUB_ENV
         echo "CSC_KEY_PASSWORD=${{ secrets.CERT_KEY_PASS }}" >> $GITHUB_ENV
         echo "CSC_IDENTITY_AUTO_DISCOVERY=false" >> $GITHUB_ENV
 

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -107,6 +107,21 @@ jobs:
     - name: NPM Install
       run: npm install
 
+    - name: Run the build script
+      run: npm run build
+
+    - name: Run electron-builder on macOS
+      if: matrix.os == 'macos-latest'
+      run: npx --no-install electron-builder --mac ${args}
+
+    - name: Run electron-builder on windows
+      if: matrix.os == 'windows-latest'
+      run: npx --no-install electron-builder --windows ${args}
+
+    - name: Run electron-builder on ubuntu
+      if: matrix.os == 'ubuntu-latest'
+      run: npx --no-install electron-builder --linux ${args}
+
     - name: Build & Release Electron application
       uses: samuelmeuli/action-electron-builder@v1
       if: ${{ always() }}

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -112,6 +112,21 @@ jobs:
     - name: Run the build script
       run: npm run build
 
+    - name: Download code-signing certificate, set env vars
+      # electron-builder code signing only supported on macos and windows
+      if: matrix.os == 'macos-latest' || matrix.os == 'windows-latest' 
+      run: |
+        P12_FILENAME=Stanford-natcap-code-signing-2019-03-07.p12
+        CERTIFICATE_PATH='~/Downloads/$(P12_FILE)'
+        gsutil cp 'gs://stanford_cert/$(P12_FILE)' $CERTIFICATE_PATH
+
+        # all these variables are used by electron-builder
+        echo "GH_TOKEN=${{ env.GITHUB_TOKEN }}" >> $GITHUB_ENV
+        echo "CSC_LINK=$CERTIFICATE_PATH" >> $GITHUB_ENV
+        echo "CSC_KEY_PASSWORD=${{ secrets.CERT_KEY_PASS }}" >> $GITHUB_ENV
+        echo "CSC_NAME='Stanford University'" >> $GITHUB_ENV
+        echo "CSC_IDENTITY_AUTO_DISCOVERY=false" >> $GITHUB_ENV
+
     - name: Run electron-builder on macOS
       if: matrix.os == 'macos-latest'
       env:

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -40,7 +40,7 @@ jobs:
         sudo apt-get install libspatialindex-dev
 
     - name: Set up conda for non-Windows
-      uses: goanpeca/setup-miniconda@v2
+      uses: conda-incubator/setup-miniconda@v2
       if: matrix.os != 'windows-latest'
       with:
         activate-environment: invest-env

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -117,7 +117,6 @@ jobs:
     - name: Set up GCP
       # Secrets not available in PR so don't use GCP.
       if: github.event_name != 'pull_request'
-      shell: bash -l {0} 
       uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
       with:
           version: '281.0.0'

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -30,13 +30,13 @@ jobs:
     - name: test env var
       shell: bash
       env:
-          INVEST_VERSION: jq -r .invest.version package.json
+          INVEST_VERSION: $(jq -r .invest.version package.json)
       run: echo ${{ env.INVEST_VERSION }}
 
     - name: Clone natcap/invest
       uses: actions/checkout@v2
       env:
-        INVEST_VERSION: jq -r .invest.version package.json
+        INVEST_VERSION: $(jq -r .invest.version package.json)
       with:
         repository: natcap/invest
         ref: refs/tags/${{env.INVEST_VERSION}}

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -133,14 +133,16 @@ jobs:
 
         gsutil cp gs://stanford_cert/$P12_FILE ~/$P12_FILE
 
-        KEYCHAIN_NAME=fake-keychain
-        KEYCHAIN_PASS=fake-password
         echo $KEYCHAIN_NAME
-        echo $KEYCHAIN_PASS
+
         security list-keychains
         security create-keychain -p $KEYCHAIN_PASS $KEYCHAIN_NAME
         security list-keychains -s $KEYCHAIN_NAME
         security list-keychains
+
+        echo 'listed keychains'
+        security unlock-keychain -p $KEYCHAIN_PASS $KEYCHAIN_NAME
+        echo 'unlocked keychain'
 
         # # unlock the keychain so we can import to it (stays unlocked 5 minutes by default)
         # security unlock-keychain -p $KEYCHAIN_PASS $KEYCHAIN_NAME

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -131,34 +131,18 @@ jobs:
       run: |
         set +x
 
-        gsutil cp gs://stanford_cert/$P12_FILE ~/$P12_FILE
+        gsutil cp gs://stanford_cert/$P12_FILE ~/$P12_FILE 
 
-        echo $KEYCHAIN_NAME
+        pwd
 
-        security list-keychains
-        security create-keychain -p $KEYCHAIN_PASS $KEYCHAIN_NAME
-        security list-keychains -s $KEYCHAIN_NAME
-        security list-keychains
+        bash ./scripts/setup_macos_keychain.sh $KEYCHAIN_NAME $KEYCHAIN_PASS ~/$P12_FILE $CERT_KEY_PASS
 
-        echo 'listed keychains'
-        security unlock-keychain -p $KEYCHAIN_PASS $KEYCHAIN_NAME
-        echo 'unlocked keychain'
+        # these env variables tell electron-builder to do code signing
+        echo "CSC_KEYCHAIN=$KEYCHAIN_NAME" >> $GITHUB_ENV
+        echo "CSC_NAME='Stanford University'" >> $GITHUB_ENV
+        echo "CSC_IDENTITY_AUTO_DISCOVERY=false" >> $GITHUB_ENV
 
-        # # unlock the keychain so we can import to it (stays unlocked 5 minutes by default)
-        # security unlock-keychain -p $KEYCHAIN_PASS $KEYCHAIN_NAME
-        # # add the certificate to the keychain
-        # # -T option says that the codesign executable can access the keychain
-        # # for some reason this alone is not enough, also need the following step
-        # security import $BUILD_DIR/$P12_FILE -k $KEYCHAIN_NAME -P $CERT_KEY_PASS -T /usr/bin/codesign
-        # # this is essential to avoid the UI password prompt
-        # security set-key-partition-list -S apple-tool:,apple: -s -k $KEYCHAIN_PASS $KEYCHAIN_NAME
-
-        # # these env variables tell electron-builder to do code signing
-        # echo "CSC_KEYCHAIN=$KEYCHAIN_NAME" >> $GITHUB_ENV
-        # echo "CSC_NAME='Stanford University'" >> $GITHUB_ENV
-        # echo "CSC_IDENTITY_AUTO_DISCOVERY=false" >> $GITHUB_ENV
-
-        # # echo "CSC_KEY_PASSWORD=${{ secrets.CERT_KEY_PASS }}" >> $GITHUB_ENV
+        # echo "CSC_KEY_PASSWORD=${{ secrets.CERT_KEY_PASS }}" >> $GITHUB_ENV
        
 
     - name: Code-signing for Windows

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -21,16 +21,22 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
 
+    - name: Set env var
+      shell: bash
+      run:
+        INVEST_VERSION=$(jq -r .invest.version package.json)
+        echo $INVEST_VERSION
+        echo "INVEST_VERSION=$INVEST_VERSION"
+        echo "action_state=$INVEST_VERSION" >> $GITHUB_ENV
+
     - name: test env var
       shell: bash
       env:
-          INVEST_VERSION: $(jq -r .invest.version package.json)
-      run: echo ${{ env.INVEST_VERSION }}
+        INVEST_VERSION: 
+      run: echo "${{ env.INVEST_VERSION }}"
 
     - name: Clone natcap/invest
       uses: actions/checkout@v2
-      env:
-        INVEST_VERSION: $(jq -r .invest.version package.json)
       with:
         repository: natcap/invest
         ref: "refs/tags/${{ env.INVEST_VERSION }}"

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -134,10 +134,13 @@ jobs:
         gsutil cp gs://stanford_cert/$P12_FILE ~/$P12_FILE
 
         security list-keychains
-        security create-keychain -p $KEYCHAIN_PASS $KEYCHAIN_NAME
-        security list-keychains -s $KEYCHAIN_NAME
+        security create-keychain -p fake-password fake-keychain
+        security list-keychains -s fake-keychain
         security list-keychains
-        
+        # security create-keychain -p $KEYCHAIN_PASS $KEYCHAIN_NAME
+        # security list-keychains -s $KEYCHAIN_NAME
+        # security list-keychains
+
         # # unlock the keychain so we can import to it (stays unlocked 5 minutes by default)
         # security unlock-keychain -p $KEYCHAIN_PASS $KEYCHAIN_NAME
         # # add the certificate to the keychain

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -23,9 +23,9 @@ jobs:
     
     - name: Set env var for invest version
       shell: bash
-      run: 
+      run: |
         jq -r .invest.version package.json
-        echo "{INVEST_VERSION}={$(jq -r .invest.version package.json)}" >> $GITHUB_ENV
+        # echo "{INVEST_VERSION}={$(jq -r .invest.version package.json)}" >> $GITHUB_ENV
 
     - name: test env var
       shell: bash

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -129,29 +129,32 @@ jobs:
         CERT_KEY_PASS: ${{ secrets.STANFORD_CERT_KEY_PASS }}
 
       run: |
+        set +x
+        
         # download the p12 certificate file from google cloud
         gsutil cp gs://stanford_cert/$P12_FILE ~/$P12_FILE
+
         security list-keychains
         # create a new keychain (so that we can know what the password is)
         security create-keychain -p $KEYCHAIN_PASS $KEYCHAIN_NAME
         # add the keychain to the search list so it can be found
         security list-keychains -s $KEYCHAIN_NAME
         security list-keychains
-        # unlock the keychain so we can import to it (stays unlocked 5 minutes by default)
-        security unlock-keychain -p $KEYCHAIN_PASS $KEYCHAIN_NAME
-        # add the certificate to the keychain
-        # -T option says that the codesign executable can access the keychain
-        # for some reason this alone is not enough, also need the following step
-        security import $BUILD_DIR/$P12_FILE -k $KEYCHAIN_NAME -P $CERT_KEY_PASS -T /usr/bin/codesign
-        # this is essential to avoid the UI password prompt
-        security set-key-partition-list -S apple-tool:,apple: -s -k $KEYCHAIN_PASS $KEYCHAIN_NAME
+        # # unlock the keychain so we can import to it (stays unlocked 5 minutes by default)
+        # security unlock-keychain -p $KEYCHAIN_PASS $KEYCHAIN_NAME
+        # # add the certificate to the keychain
+        # # -T option says that the codesign executable can access the keychain
+        # # for some reason this alone is not enough, also need the following step
+        # security import $BUILD_DIR/$P12_FILE -k $KEYCHAIN_NAME -P $CERT_KEY_PASS -T /usr/bin/codesign
+        # # this is essential to avoid the UI password prompt
+        # security set-key-partition-list -S apple-tool:,apple: -s -k $KEYCHAIN_PASS $KEYCHAIN_NAME
 
-        # these env variables tell electron-builder to do code signing
-        echo "CSC_KEYCHAIN=$KEYCHAIN_NAME" >> $GITHUB_ENV
-        echo "CSC_NAME='Stanford University'" >> $GITHUB_ENV
-        echo "CSC_IDENTITY_AUTO_DISCOVERY=false" >> $GITHUB_ENV
+        # # these env variables tell electron-builder to do code signing
+        # echo "CSC_KEYCHAIN=$KEYCHAIN_NAME" >> $GITHUB_ENV
+        # echo "CSC_NAME='Stanford University'" >> $GITHUB_ENV
+        # echo "CSC_IDENTITY_AUTO_DISCOVERY=false" >> $GITHUB_ENV
 
-        # echo "CSC_KEY_PASSWORD=${{ secrets.CERT_KEY_PASS }}" >> $GITHUB_ENV
+        # # echo "CSC_KEY_PASSWORD=${{ secrets.CERT_KEY_PASS }}" >> $GITHUB_ENV
        
 
     - name: Code-signing for Windows

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -116,19 +116,19 @@ jobs:
       if: matrix.os == 'macos-latest'
       env:
         GH_TOKEN: env.GITHUB_TOKEN
-      run: npx --no-install electron-builder build --mac -c.extraMetadata.main=build/main.js
+      run: npx --no-install electron-builder build --mac -c.extraMetadata.main=build/main.js --publish never
 
     - name: Run electron-builder on windows
       if: matrix.os == 'windows-latest'
       env:
         GH_TOKEN: env.GITHUB_TOKEN
-      run: npx --no-install electron-builder build --windows -c.extraMetadata.main=build/main.js
+      run: npx --no-install electron-builder build --windows -c.extraMetadata.main=build/main.js --publish never
 
     - name: Run electron-builder on ubuntu
       if: matrix.os == 'ubuntu-latest'
       env:
         GH_TOKEN: env.GITHUB_TOKEN
-      run: npx --no-install electron-builder build --linux -c.extraMetadata.main=build/main.js
+      run: npx --no-install electron-builder build --linux -c.extraMetadata.main=build/main.js --publish never
 
       # Also run all tests on the build dir code?
     - name: Test flask app binaries

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -126,7 +126,7 @@ jobs:
       run: |
         P12_FILE=Stanford-natcap-code-signing-2019-03-07.p12
         CERTIFICATE_PATH='~/Downloads/$(P12_FILE)'
-        gsutil cp 'gs://stanford_cert/$(P12_FILE)' $CERTIFICATE_PATH
+        gsutil cp gs://stanford_cert/$(P12_FILE) $CERTIFICATE_PATH
 
         # all these variables are used by electron-builder
         echo "GH_TOKEN=${{ env.GITHUB_TOKEN }}" >> $GITHUB_ENV

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -112,6 +112,14 @@ jobs:
     - name: Run the build script
       run: npm run build
 
+    - name: Set up GCP
+      # Secrets not available in PR so don't use GCP.
+      if: github.event_name != 'pull_request'
+      uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+      with:
+          version: '281.0.0'
+          service_account_key: ${{ secrets.GOOGLE_SERVICE_ACC_KEY }}
+
     - name: Download code-signing certificate, set env vars
       # electron-builder code signing only supported on macos and windows
       if: matrix.os == 'macos-latest' || matrix.os == 'windows-latest' 

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -119,23 +119,21 @@ jobs:
           service_account_key: ${{ secrets.GOOGLE_SERVICE_ACC_KEY }}
 
     # electron-builder code signing only supported on macos and windows
-    - name: Code-signing for macOS
+    - name: Code-signing setup for macOS
       if: matrix.os == 'macos-latest'
       shell: bash
       env:
-        P12_FILE: Stanford-natcap-code-signing-2019-03-07.p12
+        P12_FILE_PATH: ~/Downloads/stanford_cert.p12
         KEYCHAIN_NAME: codesign_keychain
         KEYCHAIN_PASS: ${{ secrets.KEYCHAIN_PASS }}
         CERT_KEY_PASS: ${{ secrets.STANFORD_CERT_KEY_PASS }}
 
       run: |
-        set +x
-
-        gsutil cp gs://stanford_cert/$P12_FILE ~/$P12_FILE 
+        gsutil cp gs://stanford_cert/Stanford-natcap-code-signing-2019-03-07.p12 $P12_FILE_PATH 
 
         pwd
-
-        bash ./scripts/setup_macos_keychain.sh $KEYCHAIN_NAME $KEYCHAIN_PASS ~/$P12_FILE $CERT_KEY_PASS
+        echo $P12_FILE_PATH
+        bash ./scripts/setup_macos_keychain.sh $KEYCHAIN_NAME $KEYCHAIN_PASS $P12_FILE_PATH $CERT_KEY_PASS
 
         # these env variables tell electron-builder to do code signing
         echo "CSC_KEYCHAIN=$KEYCHAIN_NAME" >> $GITHUB_ENV
@@ -145,7 +143,7 @@ jobs:
         # echo "CSC_KEY_PASSWORD=${{ secrets.CERT_KEY_PASS }}" >> $GITHUB_ENV
        
 
-    - name: Code-signing for Windows
+    - name: Code-signing setup for Windows
       if: matrix.os == 'windows-latest'
       env:
         P12_FILE: Stanford-natcap-code-signing-2019-03-07.p12

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -40,7 +40,7 @@ jobs:
         sudo apt-get install libspatialindex-dev
 
     - name: Set up conda for non-Windows
-      uses: goanpeca/setup-miniconda@v1.1.2
+      uses: goanpeca/setup-miniconda@v2
       if: matrix.os != 'windows-latest'
       with:
         activate-environment: invest-env

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -133,7 +133,8 @@ jobs:
 
         pwd
         echo $P12_FILE_PATH
-        bash ./scripts/setup_macos_keychain.sh $KEYCHAIN_NAME $KEYCHAIN_PASS $P12_FILE_PATH $CERT_KEY_PASS
+        CERT_KEY_PASS=fake-pass
+        bash ./scripts/setup_macos_keychain.sh $KEYCHAIN_NAME $KEYCHAIN_PASS $CERT_KEY_PASS $P12_FILE_PATH 
 
         # these env variables tell electron-builder to do code signing
         echo "CSC_KEYCHAIN=$KEYCHAIN_NAME" >> $GITHUB_ENV

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -122,17 +122,6 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
       run: npx --no-install electron-builder --linux -c.extraMetadata.main=build/main.js
 
-    - name: Build & Release Electron application
-      uses: samuelmeuli/action-electron-builder@v1
-      if: ${{ always() }}
-      with:
-        build_script_name: build
-        args: -c.extraMetadata.main=build/main.js
-        github_token: ${{ secrets.github_token }}
-        # If the commit is tagged with a version (e.g. "v1.0.0"),
-        # release the app after building
-        release: ${{ startsWith(github.ref, 'refs/tags/v') }}
-
       # Also run all tests on the build dir code?
     - name: Test flask app binaries
       shell: bash -l {0}

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -125,8 +125,8 @@ jobs:
       if: matrix.os == 'macos-latest' || matrix.os == 'windows-latest' 
       run: |
         P12_FILE=Stanford-natcap-code-signing-2019-03-07.p12
-        CERTIFICATE_PATH='~/Downloads/$(P12_FILE)'
-        gsutil cp gs://stanford_cert/$(P12_FILE) $CERTIFICATE_PATH
+        CERTIFICATE_PATH=~/Downloads/$P12_FILE
+        gsutil cp gs://stanford_cert/$P12_FILE $CERTIFICATE_PATH
 
         # all these variables are used by electron-builder
         echo "GH_TOKEN=${{ env.GITHUB_TOKEN }}" >> $GITHUB_ENV

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -124,7 +124,7 @@ jobs:
       # electron-builder code signing only supported on macos and windows
       if: matrix.os == 'macos-latest' || matrix.os == 'windows-latest' 
       run: |
-        P12_FILENAME=Stanford-natcap-code-signing-2019-03-07.p12
+        P12_FILE=Stanford-natcap-code-signing-2019-03-07.p12
         CERTIFICATE_PATH='~/Downloads/$(P12_FILE)'
         gsutil cp 'gs://stanford_cert/$(P12_FILE)' $CERTIFICATE_PATH
 

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -112,14 +112,20 @@ jobs:
 
     - name: Run electron-builder on macOS
       if: matrix.os == 'macos-latest'
+      env:
+        GH_TOKEN: env.GITHUB_TOKEN
       run: npx --no-install electron-builder --mac -c.extraMetadata.main=build/main.js
 
     - name: Run electron-builder on windows
       if: matrix.os == 'windows-latest'
+      env:
+        GH_TOKEN: env.GITHUB_TOKEN
       run: npx --no-install electron-builder --windows -c.extraMetadata.main=build/main.js
 
     - name: Run electron-builder on ubuntu
       if: matrix.os == 'ubuntu-latest'
+      env:
+        GH_TOKEN: env.GITHUB_TOKEN
       run: npx --no-install electron-builder --linux -c.extraMetadata.main=build/main.js
 
       # Also run all tests on the build dir code?

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -135,7 +135,7 @@ jobs:
         echo "GH_TOKEN=${{ env.GITHUB_TOKEN }}" >> $GITHUB_ENV
         echo "CSC_LINK=$CERTIFICATE_PATH" >> $GITHUB_ENV
         echo "CSC_KEY_PASSWORD=${{ secrets.CERT_KEY_PASS }}" >> $GITHUB_ENV
-        echo "CSC_NAME='Stanford University'" >> $GITHUB_ENV
+        # echo "CSC_NAME='Stanford University'" >> $GITHUB_ENV
         echo "CSC_IDENTITY_AUTO_DISCOVERY=false" >> $GITHUB_ENV
 
     - name: Run electron-builder on macOS

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "babel-eslint": "^10.1.0",
     "dotenv": "^8.2.0",
     "electron": "^10.1.2",
-    "electron-builder": "^22.8.0",
+    "electron-builder": "^22.9.1",
     "electron-devtools-installer": "^3.1.1",
     "eslint": "^7.9.0",
     "eslint-config-airbnb": "^18.2.0",

--- a/scripts/setup_macos_keychain.sh
+++ b/scripts/setup_macos_keychain.sh
@@ -1,0 +1,27 @@
+#!/bin/bash -ve
+
+#
+# Arguments:
+#  $1 = the name to give the new keychain
+#  $2 = the keychain password to set
+#  $3 = path to .p12 certificate file to add to keychain
+#  $4 = .p12 certificate file password
+
+security list-keychains
+security create-keychain -p $2 $1
+security list-keychains -s $1
+security list-keychains
+
+echo 'listed keychains'
+# unlock the keychain so we can import to it (stays unlocked 5 minutes by default)
+security unlock-keychain -p $2 $1
+echo 'unlocked keychain'
+
+# add the certificate to the keychain
+# -T option says that the codesign executable can access the keychain
+# for some reason this alone is not enough, also need the following step
+security import $3 -k $1 -P $4 -T /usr/bin/codesign
+# this is essential to avoid the UI password prompt
+security set-key-partition-list -S apple-tool:,apple: -s -k $2 $1
+
+

--- a/scripts/setup_macos_keychain.sh
+++ b/scripts/setup_macos_keychain.sh
@@ -14,6 +14,7 @@ security list-keychains -s $1
 security list-keychains
 
 echo $1
+echo $2
 echo $3
 echo $4
 

--- a/scripts/setup_macos_keychain.sh
+++ b/scripts/setup_macos_keychain.sh
@@ -7,10 +7,14 @@
 #  $3 = path to .p12 certificate file to add to keychain
 #  $4 = .p12 certificate file password
 
+
 security list-keychains
 security create-keychain -p $2 $1
 security list-keychains -s $1
 security list-keychains
+
+echo $1
+echo $3
 
 echo 'listed keychains'
 # unlock the keychain so we can import to it (stays unlocked 5 minutes by default)
@@ -21,6 +25,8 @@ echo 'unlocked keychain'
 # -T option says that the codesign executable can access the keychain
 # for some reason this alone is not enough, also need the following step
 security import $3 -k $1 -P $4 -T /usr/bin/codesign
+
+echo 'imported cert'
 # this is essential to avoid the UI password prompt
 security set-key-partition-list -S apple-tool:,apple: -s -k $2 $1
 

--- a/scripts/setup_macos_keychain.sh
+++ b/scripts/setup_macos_keychain.sh
@@ -1,35 +1,25 @@
 #!/bin/bash -ve
 
-#
-# Arguments:
-#  $1 = the name to give the new keychain
-#  $2 = the keychain password to set
-#  $3 = path to .p12 certificate file to add to keychain
-#  $4 = .p12 certificate file password
-
+# The environment variables referenced should be set by the calling github actions step
 
 security list-keychains
-security create-keychain -p $2 $1
-security list-keychains -s $1
+security create-keychain -p $KEYCHAIN_PASS $KEYCHAIN_NAME
+security list-keychains -s $KEYCHAIN_NAME
 security list-keychains
 
-echo $1
-echo $2
-echo $3
-echo $4
 
 echo 'listed keychains'
 # unlock the keychain so we can import to it (stays unlocked 5 minutes by default)
-security unlock-keychain -p $2 $1
+security unlock-keychain -p $KEYCHAIN_PASS $KEYCHAIN_NAME
 echo 'unlocked keychain'
 
 # add the certificate to the keychain
 # -T option says that the codesign executable can access the keychain
 # for some reason this alone is not enough, also need the following step
-security import $3 -k $1 -P $4 -T /usr/bin/codesign
+security import $P12_FILE_PATH -k $KEYCHAIN_NAME -P $CERT_KEY_PASS -T /usr/bin/codesign
 
 echo 'imported cert'
 # this is essential to avoid the UI password prompt
-security set-key-partition-list -S apple-tool:,apple: -s -k $2 $1
+security set-key-partition-list -S apple-tool:,apple: -s -k $KEYCHAIN_PASS $KEYCHAIN_NAME
 
 

--- a/scripts/setup_macos_keychain.sh
+++ b/scripts/setup_macos_keychain.sh
@@ -22,4 +22,4 @@ echo 'imported cert'
 # this is essential to avoid the UI password prompt
 security set-key-partition-list -S apple-tool:,apple: -s -k $KEYCHAIN_PASS $KEYCHAIN_NAME
 
-
+security find-certificate -c 'Stanford University'

--- a/scripts/setup_macos_keychain.sh
+++ b/scripts/setup_macos_keychain.sh
@@ -15,6 +15,7 @@ security list-keychains
 
 echo $1
 echo $3
+echo $4
 
 echo 'listed keychains'
 # unlock the keychain so we can import to it (stays unlocked 5 minutes by default)


### PR DESCRIPTION
Fixes #28
* Remove deprecated set-env command from Github Actions workflow (support ends on 11/16). Instead save to github env file (see [this post](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/))
* Update setup-miniconda actions version (had deprecated set-path command)
