### PR TITLE
Bugfix and cleanup for the validation feedback display

### DIFF
--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -23,13 +23,13 @@ jobs:
     
     - name: Set env var for invest version
       shell: bash
-      run: echo ::set-env name=INVEST_VERSION::$(jq -r .invest.version package.json)
+      run: echo "INVEST_VERSION=$(jq -r .invest.version package.json)" >> $GITHUB_ENV
 
     - name: Clone natcap/invest
       uses: actions/checkout@v2
       with:
         repository: natcap/invest
-        ref: refs/tags/${{env.INVEST_VERSION}}
+        ref: refs/tags/$INVEST_VERSION
         path: ./invest
 
     - name: Install libspatialindex for ubuntu

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -29,7 +29,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: natcap/invest
-        ref: refs/tags/${{INVEST_VERSION}}
+        ref: refs/tags/${{env.INVEST_VERSION}}
         path: ./invest
 
     - name: Install libspatialindex for ubuntu

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -38,7 +38,7 @@ jobs:
         sudo apt-get install libspatialindex-dev
 
     - name: Set up conda for non-Windows
-      uses: goanpeca/setup-miniconda@v1.1.2
+      uses: conda-incubator/setup-miniconda@v2
       if: matrix.os != 'windows-latest'
       with:
         activate-environment: invest-env

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -29,7 +29,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: natcap/invest
-        ref: refs/tags/$INVEST_VERSION
+        ref: refs/tags/${{INVEST_VERSION}}
         path: ./invest
 
     - name: Install libspatialindex for ubuntu

--- a/src/components/SetupTab/ArgInput/index.jsx
+++ b/src/components/SetupTab/ArgInput/index.jsx
@@ -9,6 +9,20 @@ import Row from 'react-bootstrap/Row';
 import InputGroup from 'react-bootstrap/InputGroup';
 import Modal from 'react-bootstrap/Modal';
 
+/**
+ * Filter a message that refers to many spatial inputs' bounding boxes.
+ *
+ * Messages are oneline strings with `|` separating each
+ * filename & bounding-box pair. E.g:
+ *
+ *   `Bounding boxes do not intersect:
+ *   ./a.shp: [-84.9, 19.1, -69.15, 29.5] |
+ *   ./b.shp: [-79.0198, 26.481, -78.3717, 27.268] | ...`
+ *
+ * @param {string} message - a string that contains `filepath` e.g:
+ * @param {string} filepath - string preceding the relevant part of `message`
+ * @returns {string} - the filtered and formatted part of the message
+ */
 function filterSpatialOverlapFeedback(message, filepath) {
   const newPrefix = 'Bounding box does not intersect at least one other:';
   const bbox = message.split(`${filepath}:`).pop().split('|')[0];

--- a/src/components/SetupTab/ArgInput/index.jsx
+++ b/src/components/SetupTab/ArgInput/index.jsx
@@ -1,3 +1,4 @@
+import os from 'os';
 import React from 'react';
 import PropTypes from 'prop-types';
 
@@ -7,6 +8,15 @@ import Col from 'react-bootstrap/Col';
 import Row from 'react-bootstrap/Row';
 import InputGroup from 'react-bootstrap/InputGroup';
 import Modal from 'react-bootstrap/Modal';
+
+function filterSpatialOverlapFeedback(message, filepath) {
+  const newPrefix = 'Bounding box does not intersect at least one other:';
+  const bbox = message.split(`${filepath}:`).pop().split('|')[0];
+  const bboxFormatted = bbox.split(' ').map(
+    (str) => str.padEnd(22, ' ')
+  ).join('').trim();
+  return `${newPrefix}${os.EOL}${bboxFormatted}`;
+}
 
 function FormLabel(props) {
   return (
@@ -47,14 +57,31 @@ export default class ArgInput extends React.PureComponent {
       selectFile,
       touched,
       ui_option,
-      validationMessage,
       value,
     } = this.props;
+    let { validationMessage } = this.props;
     let Input;
 
+    // Messages with this pattern include validation feedback about
+    // multiple inputs, but the whole message is repeated for each input.
+    // It's more readable if filtered on the individual input.
+    const pattern = 'Bounding boxes do not intersect';
+    if (validationMessage.startsWith(pattern)) {
+      validationMessage = filterSpatialOverlapFeedback(
+        validationMessage, value
+      );
+    }
+
     // These types need a text input, and some also need a file browse button
-    if (['csv', 'vector', 'raster', 'directory', 'freestyle_string', 'number'].includes(argSpec.type)) {
-      const typeLabel = argSpec.type !== 'freestyle_string' ? argSpec.type : 'string';
+    if (
+      [
+        'csv', 'vector', 'raster', 'directory',
+        'freestyle_string', 'number',
+      ].includes(argSpec.type)
+    ) {
+      const typeLabel = argSpec.type === 'freestyle_string'
+        ? 'string'
+        : argSpec.type;
       Input = (
         <Form.Group
           as={Row}

--- a/src/components/SetupTab/ArgInput/index.jsx
+++ b/src/components/SetupTab/ArgInput/index.jsx
@@ -77,8 +77,9 @@ export default class ArgInput extends React.PureComponent {
                 placeholder={typeLabel}
                 value={value || ''} // empty string is handled better than `undefined`
                 onChange={handleChange}
+                onFocus={handleChange}
                 isValid={touched && isValid}
-                isInvalid={touched && validationMessage}
+                isInvalid={validationMessage}
                 disabled={ui_option === 'disable'}
               />
               {
@@ -98,11 +99,17 @@ export default class ArgInput extends React.PureComponent {
                   )
                   : <React.Fragment />
               }
-              <Feedback
-                argkey={argkey}
-                argtype={argSpec.type}
-                message={validationMessage}
-              />
+              {
+                (validationMessage && touched)
+                  ? (
+                    <Feedback
+                      argkey={argkey}
+                      argtype={argSpec.type}
+                      message={validationMessage}
+                    />
+                  )
+                  : <React.Fragment />
+              }
             </InputGroup>
           </Col>
         </Form.Group>
@@ -160,17 +167,24 @@ export default class ArgInput extends React.PureComponent {
                 name={argkey}
                 value={value}
                 onChange={handleChange}
+                onFocus={handleChange}
                 disabled={ui_option === 'disable'}
               >
                 {argSpec.validation_options.options.map((opt) =>
                   <option value={opt} key={opt}>{opt}</option>
                 )}
               </Form.Control>
-              <Feedback
-                argkey={argkey}
-                argtype={argSpec.type}
-                message={validationMessage}
-              />
+              {
+                (validationMessage && touched)
+                  ? (
+                    <Feedback
+                      argkey={argkey}
+                      argtype={argSpec.type}
+                      message={validationMessage}
+                    />
+                  )
+                  : <React.Fragment />
+              }
             </InputGroup>
           </Col>
         </Form.Group>

--- a/src/components/SetupTab/ArgsForm/index.jsx
+++ b/src/components/SetupTab/ArgsForm/index.jsx
@@ -14,21 +14,6 @@ function dragoverHandler(event) {
   event.dataTransfer.dropEffect = 'move';
 }
 
-function parseMultiInputFeedback(message, selector) {
-  const pattern = 'Bounding boxes do not intersect';
-  const isMultiInputFeedback = message.startsWith(pattern);
-  let newMessage = message;
-  const newPrefix = 'Bounding box does not intersect at least one other:';
-  if (isMultiInputFeedback) {
-    const bbox = message.split(`${selector}:`).pop().split('|')[0];
-    const bboxFormatted = bbox.split(' ').map(
-      (str) => str.padEnd(22, ' ')
-    ).join('').trim();
-    newMessage = `${newPrefix}${os.EOL}${bboxFormatted}`;
-  }
-  return newMessage;
-}
-
 /** Renders a form with a list of input components. */
 export default class ArgsForm extends React.Component {
   constructor(props) {
@@ -94,12 +79,6 @@ export default class ArgsForm extends React.Component {
       k += 1;
       const groupItems = [];
       groupArray.forEach((argkey) => {
-        let { validationMessage } = argsValidation[argkey];
-        if (validationMessage) {
-          validationMessage = parseMultiInputFeedback(
-            validationMessage, argsValues[argkey].value
-          );
-        }
         groupItems.push(
           <ArgInput
             key={argkey}
@@ -109,7 +88,7 @@ export default class ArgsForm extends React.Component {
             touched={argsValues[argkey].touched}
             ui_option={argsValues[argkey].ui_option}
             isValid={argsValidation[argkey].valid}
-            validationMessage={validationMessage}
+            validationMessage={argsValidation[argkey].validationMessage}
             handleChange={this.handleChange}
             handleBoolChange={this.handleBoolChange}
             selectFile={this.selectFile}

--- a/src/components/SetupTab/ArgsForm/index.jsx
+++ b/src/components/SetupTab/ArgsForm/index.jsx
@@ -1,4 +1,3 @@
-import os from 'os';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { remote } from 'electron'; // eslint-disable-line import/no-extraneous-dependencies

--- a/src/components/SetupTab/index.jsx
+++ b/src/components/SetupTab/index.jsx
@@ -285,10 +285,8 @@ export default class SetupTab extends React.Component {
     if (results.length) {
       results.forEach((result) => {
         // Each result is an array of two elements
-        // 0: array of arg keys
-        // 1: string message that pertains to those args
-        const argkeys = result[0];
-        const message = result[1];
+        const argkeys = result[0]; // array of arg keys
+        const message = result[1]; // string that describes those args
         argkeys.forEach((key) => {
           argsValidation[key].validationMessage = message;
           argsValidation[key].valid = false;

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -251,8 +251,8 @@ input[type=text]::placeholder {
 	font-size: 1.15rem;
 	font-family: monospace;
 	white-space: pre-wrap;
-	padding-left: 50px;
-	text-indent: -50px;
+	padding-left: 3rem;
+	text-indent: -3rem;
 }
 
 /* InVEST Log Tab */

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -248,7 +248,11 @@ input[type=text]::placeholder {
 }
 
 .invalid-feedback {
-	font-size: 1.05rem;
+	font-size: 1.15rem;
+	font-family: monospace;
+	white-space: pre-wrap;
+	padding-left: 50px;
+	text-indent: -50px;
 }
 
 /* InVEST Log Tab */

--- a/src/utils.js
+++ b/src/utils.js
@@ -89,13 +89,15 @@ export function argsDictFromObject(args) {
  * @param {string} dir - path to a directory
  */
 export function cleanupDir(dir) {
-  fs.readdirSync(dir).forEach((filename) => {
-    const filepath = path.join(dir, filename);
-    if (fs.lstatSync(filepath).isFile()) {
-      fs.unlinkSync(filepath);
-    } else {
-      cleanupDir(filepath);
-    }
-  });
-  fs.rmdirSync(dir);
+  if (fs.existsSync(dir)) {
+    fs.readdirSync(dir).forEach((filename) => {
+      const filepath = path.join(dir, filename);
+      if (fs.lstatSync(filepath).isFile()) {
+        fs.unlinkSync(filepath);
+      } else {
+        cleanupDir(filepath);
+      }
+    });
+    fs.rmdirSync(dir);
+  }
 }

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -376,13 +376,11 @@ describe('InVEST subprocess testing', () => {
   };
 
   const dummyTextToLog = JSON.stringify(spec.args);
-  // const logfileName = 'InVEST-natcap.invest.model-log-9999-99-99--99_99_99.txt'
   let fakeWorkspace;
   let mockInvestProc;
 
   beforeEach(() => {
     fakeWorkspace = fs.mkdtempSync(path.join('tests/data', 'data-'));
-    // const logfilePath = path.join(fakeWorkspace, logfileName);
     // Need to reset these streams since mockInvestProc is shared by tests
     // and the streams apparently receive the EOF signal in each test.
     mockInvestProc = new events.EventEmitter();
@@ -610,15 +608,17 @@ describe('InVEST subprocess testing', () => {
     fireEvent.click(execute);
     // firing execute re-assigns mockInvestProc via the spawn mock,
     // but we need to wait for that before pushing to it's stdout.
-    // Since the production code cannot 'await spawn()' (we don't want
-    // it to stop the event loop), we do this manual timeout instead.
+    // Since the production code cannot 'await spawn()',
+    // we do this manual timeout instead.
     await new Promise((resolve) => setTimeout(resolve, 500));
     mockInvestProc.stdout.push('hello from stdout');
     logTab = await findByText('Log');
     await waitFor(() => {
       expect(logTab.classList.contains('active')).toBeTruthy();
     });
-
+    mockInvestProc.emit('exit', 0);
+    // Give it time to run the listener before unmounting.
+    await new Promise((resolve) => setTimeout(resolve, 300));
     unmount();
     spy.mockRestore();
   });

--- a/tests/investtab.test.js
+++ b/tests/investtab.test.js
@@ -219,40 +219,22 @@ describe('InVEST Run Button', () => {
   });
 
   test('Changing inputs trigger validation & enable/disable Run', async () => {
-    /*
-    This tests that changes to input values trigger validation.
-    The fetchValidation return value is always mocked, but then this
-    also tests that validation results correctly enable/disable the
-    Run button and display feedback messages on invalid inputs.
-    */
     let invalidFeedback = 'is a required key';
     fetchValidation.mockResolvedValue([[['a', 'b'], invalidFeedback]]);
 
     const {
-      findByText,
-      findAllByText,
       findByLabelText,
       findByRole,
-      queryAllByText,
     } = renderInvestTab();
 
     const runButton = await findByRole('button', { name: /Run/ });
     expect(runButton).toBeDisabled();
-    // The inputs are invalid so the invalid feedback message is present.
-    // But, the inputs have not yet been touched, so the message is hidden
-    // by CSS 'display: none'. Unfortunately, the bootstrap stylesheet is
-    // not loaded in this testing DOM, so cannot assert the message is not visible.
-    const invalidInputs = await findAllByText(invalidFeedback, { exact: false });
-    invalidInputs.forEach((element) => {
-      expect(element).toBeInTheDocument();
-      // Would be nice if these worked, but they do not:
-      // expect(element).not.toBeVisible()
-      // expect(element).toHaveStyle('display: none')
-    });
 
     const a = await findByLabelText(RegExp(`${spec.args.a.name}`));
     const b = await findByLabelText(RegExp(`${spec.args.b.name}`));
-    const c = await findByLabelText(RegExp(`${spec.args.c.name}`));
+
+    expect(a).toHaveClass('is-invalid');
+    expect(b).toHaveClass('is-invalid');
 
     // These new values will be valid - Run should enable
     fetchValidation.mockResolvedValue([]);
@@ -260,10 +242,6 @@ describe('InVEST Run Button', () => {
     fireEvent.change(b, { target: { value: 1 } });
     await waitFor(() => {
       expect(runButton).toBeEnabled();
-    });
-    // Now that inputs are valid, feedback message should be cleared.
-    queryAllByText(invalidFeedback, { exact: false }).forEach((element) => {
-      expect(element).toBeNull();
     });
 
     // This new value will be invalid - Run should disable again
@@ -273,7 +251,5 @@ describe('InVEST Run Button', () => {
     await waitFor(() => {
       expect(runButton).toBeDisabled();
     });
-    expect(await findByText(invalidFeedback, { exact: false }))
-      .toBeInTheDocument();
   });
 });

--- a/tests/setuptab.test.js
+++ b/tests/setuptab.test.js
@@ -114,7 +114,6 @@ describe('Arguments form input types', () => {
     spec.args.arg.type = 'directory';
     const { findByText } = renderSetupFromSpec(spec);
     fireEvent.click(await findByText('i'));
-    // expect(true).toBe(true);
     expect(await findByText(spec.args.arg.about)).toBeInTheDocument();
   });
 });
@@ -436,10 +435,9 @@ describe('UI spec functionality', () => {
 });
 
 describe('Misc form validation stuff', () => {
-
   afterEach(() => {
     fetchValidation.mockReset();
-  })
+  });
 
   test('Validation payload is well-formatted', async () => {
     const spec = {

--- a/tests/setuptab.test.js
+++ b/tests/setuptab.test.js
@@ -62,60 +62,26 @@ describe('Arguments form input types', () => {
     );
   });
 
-  test('expect a text input for a directory', async () => {
-    spec.args.arg.type = 'directory';
-    const { findByText, findByLabelText } = renderSetupFromSpec(spec);
+  test('expect a text input and browse button for file inputs', () => {
+    const types = ['directory', 'csv', 'vector', 'raster'];
+    types.forEach(async (type) => {
+      spec.args.arg.type = type;
+      const { findByText, findByLabelText } = renderSetupFromSpec(spec);
 
-    const input = await findByLabelText(RegExp(`${spec.args.arg.name}`));
-    expect(await findByText('Browse')).toBeInTheDocument();
-    expect(input).toHaveAttribute('type', 'text');
+      const input = await findByLabelText(RegExp(`${spec.args.arg.name}`));
+      expect(input).toHaveAttribute('type', 'text');
+      expect(await findByText('Browse')).toBeInTheDocument();
+    });
   });
 
-  test('expect a text input for a csv', async () => {
-    spec.args.arg.type = 'csv';
-    const { findByText, findByLabelText } = renderSetupFromSpec(spec);
-
-    const input = await findByLabelText(RegExp(`${spec.args.arg.name}`));
-    expect(input).toHaveAttribute('type', 'text');
-    expect(await findByText('Browse')).toBeInTheDocument();
-  });
-
-  test('expect a text input for a vector', async () => {
-    spec.args.arg.type = 'vector';
-    const { findByText, findByLabelText } = renderSetupFromSpec(spec);
-
-    const input = await findByLabelText(RegExp(`${spec.args.arg.name}`));
-    expect(input).toHaveAttribute('type', 'text');
-    expect(await findByText('Browse')).toBeInTheDocument();
-  });
-
-  test('expect a text input for a raster', async () => {
-    spec.args.arg.type = 'raster';
-    const { findByText, findByLabelText } = renderSetupFromSpec(spec);
-
-    const input = await findByLabelText(RegExp(`${spec.args.arg.name}`));
-    expect(input).toHaveAttribute('type', 'text');
-    expect(await findByText('Browse')).toBeInTheDocument();
-  });
-
-  test('expect a text input for a freestyle_string', async () => {
-    // This turned out to be an important test that caught an unrelated bug
-    // that all other tests missed -- changing only the `value` of the input
-    // while not changing the validation state revealed the problem of using
-    // a PureComponent for ArgsForm. PureComponents check for shallow-equality
-    // of props and avoid re-rendering if equal. This test alone maintained
-    // shallow-equality in a case where we definitely do need to re-render.
-    spec.args.arg.type = 'freestyle_string';
-    const { findByLabelText } = renderSetupFromSpec(spec);
-    const input = await findByLabelText(RegExp(`${spec.args.arg.name}`));
-    expect(input).toHaveAttribute('type', 'text');
-  });
-
-  test('expect a text input for a number', async () => {
-    spec.args.arg.type = 'number';
-    const { findByLabelText } = renderSetupFromSpec(spec);
-    const input = await findByLabelText(RegExp(`${spec.args.arg.name}`));
-    expect(input).toHaveAttribute('type', 'text');
+  test('expect a text input for a freestyle_string or number', () => {
+    const types = ['freestyle_string', 'number'];
+    types.forEach(async (type) => {
+      spec.args.arg.type = type;
+      const { findByLabelText } = renderSetupFromSpec(spec);
+      const input = await findByLabelText(RegExp(`${spec.args.arg.name}`));
+      expect(input).toHaveAttribute('type', 'text');
+    });
   });
 
   test('expect a radio button for a boolean', async () => {
@@ -159,7 +125,7 @@ describe('Arguments form interactions', () => {
         arg: {
           name: 'foo',
           type: undefined, // varies by test
-          required: undefined,
+          required: undefined, // varies by test
           about: 'this is about foo',
         },
       },

--- a/tests/setuptab.test.js
+++ b/tests/setuptab.test.js
@@ -63,31 +63,32 @@ describe('Arguments form input types', () => {
     );
   });
 
-  test('expect a text input and browse button for file inputs', async () => {
-    const types = ['directory', 'csv', 'vector', 'raster'];
-    types.forEach(async (type) => {
-      const spec = { ...baseSpec };
-      spec.args.arg.type = type;
-      const { findByText, findByLabelText } = renderSetupFromSpec(spec);
-
-      const input = await findByLabelText(RegExp(`${spec.args.arg.name}`));
-      expect(input).toHaveAttribute('type', 'text');
-      expect(await findByText('Browse')).toBeInTheDocument();
-    });
+  test.each([
+    ['directory'],
+    ['csv'],
+    ['vector'],
+    ['raster'],
+  ])('render a text input & browse button for a %s', async (type) => {
+    const spec = { ...baseSpec };
+    spec.args.arg.type = type;
+    const { findByText, findByLabelText } = renderSetupFromSpec(spec);
+    const input = await findByLabelText(RegExp(`${spec.args.arg.name}`));
+    expect(input).toHaveAttribute('type', 'text');
+    expect(await findByText('Browse')).toBeInTheDocument();
   });
 
-  test('expect a text input for a freestyle_string or number', async () => {
-    const types = ['freestyle_string', 'number'];
-    types.forEach(async (type) => {
-      const spec = { ...baseSpec };
-      spec.args.arg.type = type;
-      const { findByLabelText } = renderSetupFromSpec(spec);
-      const input = await findByLabelText(RegExp(`${spec.args.arg.name}`));
-      expect(input).toHaveAttribute('type', 'text');
-    });
+  test.each([
+    ['freestyle_string'],
+    ['number'],
+  ])('render a text input for a %s', async (type) => {
+    const spec = { ...baseSpec };
+    spec.args.arg.type = type;
+    const { findByLabelText } = renderSetupFromSpec(spec);
+    const input = await findByLabelText(RegExp(`${spec.args.arg.name}`));
+    expect(input).toHaveAttribute('type', 'text');
   });
 
-  test('expect a radio button for a boolean', async () => {
+  test('render an unchecked radio button for a boolean', async () => {
     const spec = { ...baseSpec };
     spec.args.arg.type = 'boolean';
     const { findByLabelText } = renderSetupFromSpec(spec);
@@ -96,7 +97,7 @@ describe('Arguments form input types', () => {
     expect(input).not.toBeChecked();
   });
 
-  test('expect a select input for an option_string', async () => {
+  test('render a select input for an option_string', async () => {
     const spec = { ...baseSpec };
     spec.args.arg.type = 'option_string';
     spec.args.arg.validation_options = {
@@ -113,7 +114,7 @@ describe('Arguments form input types', () => {
     spec.args.arg.type = 'directory';
     const { findByText } = renderSetupFromSpec(spec);
     fireEvent.click(await findByText('i'));
-    expect(true).toBe(true);
+    // expect(true).toBe(true);
     expect(await findByText(spec.args.arg.about)).toBeInTheDocument();
   });
 });

--- a/tests/setuptab.test.js
+++ b/tests/setuptab.test.js
@@ -14,9 +14,10 @@ jest.mock('../src/server_requests');
 
 const MODULE = 'carbon';
 
-function renderSetupFromSpec(spec, uiSpec = {}) {
+function renderSetupFromSpec(baseSpec, uiSpec = {}) {
   // some ARGS_SPEC boilerplate that is not under test,
   // but is required by PropType-checking
+  const spec = { ...baseSpec };
   if (!spec.modelName) { spec.modelName = 'Eco Model'; }
   if (!spec.module) { spec.module = 'natcap.invest.dot'; }
 
@@ -40,14 +41,14 @@ function renderSetupFromSpec(spec, uiSpec = {}) {
 
 describe('Arguments form input types', () => {
   const validationMessage = 'invalid because';
-  let spec;
+  let baseSpec;
 
   afterEach(() => {
     jest.resetAllMocks();
   });
 
   beforeEach(() => {
-    spec = {
+    baseSpec = {
       args: {
         arg: {
           name: 'foo',
@@ -58,13 +59,14 @@ describe('Arguments form input types', () => {
       },
     };
     fetchValidation.mockResolvedValue(
-      [[Object.keys(spec.args), validationMessage]]
+      [[Object.keys(baseSpec.args), validationMessage]]
     );
   });
 
-  test('expect a text input and browse button for file inputs', () => {
+  test('expect a text input and browse button for file inputs', async () => {
     const types = ['directory', 'csv', 'vector', 'raster'];
     types.forEach(async (type) => {
+      const spec = { ...baseSpec };
       spec.args.arg.type = type;
       const { findByText, findByLabelText } = renderSetupFromSpec(spec);
 
@@ -74,9 +76,10 @@ describe('Arguments form input types', () => {
     });
   });
 
-  test('expect a text input for a freestyle_string or number', () => {
+  test('expect a text input for a freestyle_string or number', async () => {
     const types = ['freestyle_string', 'number'];
     types.forEach(async (type) => {
+      const spec = { ...baseSpec };
       spec.args.arg.type = type;
       const { findByLabelText } = renderSetupFromSpec(spec);
       const input = await findByLabelText(RegExp(`${spec.args.arg.name}`));
@@ -85,6 +88,7 @@ describe('Arguments form input types', () => {
   });
 
   test('expect a radio button for a boolean', async () => {
+    const spec = { ...baseSpec };
     spec.args.arg.type = 'boolean';
     const { findByLabelText } = renderSetupFromSpec(spec);
     const input = await findByLabelText(RegExp(`${spec.args.arg.name}`));
@@ -93,6 +97,7 @@ describe('Arguments form input types', () => {
   });
 
   test('expect a select input for an option_string', async () => {
+    const spec = { ...baseSpec };
     spec.args.arg.type = 'option_string';
     spec.args.arg.validation_options = {
       options: ['a', 'b']
@@ -104,9 +109,11 @@ describe('Arguments form input types', () => {
   });
 
   test('expect the info dialog contains text about input', async () => {
+    const spec = { ...baseSpec };
     spec.args.arg.type = 'directory';
     const { findByText } = renderSetupFromSpec(spec);
     fireEvent.click(await findByText('i'));
+    expect(true).toBe(true);
     expect(await findByText(spec.args.arg.about)).toBeInTheDocument();
   });
 });
@@ -550,7 +557,7 @@ test('SetupTab: test dragover of a datastack/logfile', async () => {
   // })
   // fireEvent.drop(setupForm, dropEvent)
 
-  // Below is a patch similar to the one described here:
+  // Below is a patch similar to the one noted here:
   // https://github.com/testing-library/react-testing-library/issues/339
   const fileDropEvent = createEvent.drop(setupForm);
   const fileArray = ['foo.txt'];

--- a/tests/setuptab.test.js
+++ b/tests/setuptab.test.js
@@ -1,5 +1,5 @@
-import React from 'react';
 import { remote } from 'electron';
+import React from 'react';
 import {
   createEvent, fireEvent, render, waitFor
 } from '@testing-library/react';
@@ -39,140 +39,63 @@ function renderSetupFromSpec(spec, uiSpec = {}) {
 }
 
 describe('Arguments form input types', () => {
+  const validationMessage = 'invalid because';
+  let spec;
+
   afterEach(() => {
     jest.resetAllMocks();
   });
 
-  const validationMessage = 'invalid because';
-
-  test('expect a text input for a directory', async () => {
-    const spec = {
+  beforeEach(() => {
+    spec = {
       args: {
         arg: {
-          name: 'Workspace',
-          type: 'directory',
-          about: 'this is a workspace',
+          name: 'foo',
+          type: undefined, // varies by test
+          required: undefined,
+          about: 'this is about foo',
         },
       },
     };
     fetchValidation.mockResolvedValue(
       [[Object.keys(spec.args), validationMessage]]
     );
-    const { findByText, findByLabelText } = renderSetupFromSpec(spec);
-    const input = await findByLabelText(RegExp(`${spec.args.arg.name}`));
-    expect(input).toHaveAttribute('type', 'text');
-    expect(await findByText('Browse')).toBeInTheDocument();
-    fireEvent.change(input, { target: { value: 'foo' } });
-    await waitFor(() => {
-      expect(input).toHaveValue('foo');
-      expect(input.classList.contains('is-invalid')).toBeTruthy();
-    });
-    expect(await findByText(validationMessage, { exact: false }))
-      .toBeInTheDocument();
+  });
 
-    // Expect the info dialog contains the about text, when clicked
-    fireEvent.click(await findByText('i'));
-    expect(await findByText(spec.args.arg.about)).toBeInTheDocument();
+  test('expect a text input for a directory', async () => {
+    spec.args.arg.type = 'directory';
+    const { findByText, findByLabelText } = renderSetupFromSpec(spec);
+
+    const input = await findByLabelText(RegExp(`${spec.args.arg.name}`));
+    expect(await findByText('Browse')).toBeInTheDocument();
+    expect(input).toHaveAttribute('type', 'text');
   });
 
   test('expect a text input for a csv', async () => {
-    /** Also testing the browse button functionality */
-
-    const spec = {
-      args: {
-        arg: {
-          name: 'foo',
-          type: 'csv',
-        },
-      },
-    };
-    fetchValidation.mockResolvedValue(
-      [[Object.keys(spec.args), validationMessage]]
-    );
+    spec.args.arg.type = 'csv';
     const { findByText, findByLabelText } = renderSetupFromSpec(spec);
+
     const input = await findByLabelText(RegExp(`${spec.args.arg.name}`));
     expect(input).toHaveAttribute('type', 'text');
     expect(await findByText('Browse')).toBeInTheDocument();
-    fireEvent.change(input, { target: { value: 'foo' } });
-    await waitFor(() => {
-      expect(input).toHaveValue('foo');
-      expect(input.classList.contains('is-invalid')).toBeTruthy();
-    });
-    expect(await findByText(validationMessage, { exact: false }))
-      .toBeInTheDocument();
-
-    // Browsing for a file
-    const filepath = 'grilled_cheese.csv';
-    let mockDialogData = { filePaths: [filepath] };
-    remote.dialog.showOpenDialog.mockResolvedValue(mockDialogData);
-    fireEvent.click(await findByText('Browse'));
-    await waitFor(() => {
-      expect(input).toHaveValue(filepath);
-      expect(input.classList.contains('is-invalid')).toBeTruthy();
-    });
-    expect(await findByText(validationMessage, { exact: false }))
-      .toBeInTheDocument();
-
-    // Now browse again, but this time cancel it and expect the previous value
-    mockDialogData = { filePaths: [] }; // empty array is a mocked 'Cancel'
-    remote.dialog.showOpenDialog.mockResolvedValue(mockDialogData);
-    fireEvent.click(await findByText('Browse'));
-    await waitFor(() => {
-      expect(input).toHaveValue(filepath);
-      expect(input.classList.contains('is-invalid')).toBeTruthy();
-    });
-    expect(await findByText(validationMessage, { exact: false }))
-      .toBeInTheDocument();
   });
 
   test('expect a text input for a vector', async () => {
-    const spec = {
-      args: {
-        arg: {
-          name: 'foo',
-          type: 'vector',
-        },
-      },
-    };
-    fetchValidation.mockResolvedValue(
-      [[Object.keys(spec.args), validationMessage]]
-    );
+    spec.args.arg.type = 'vector';
     const { findByText, findByLabelText } = renderSetupFromSpec(spec);
+
     const input = await findByLabelText(RegExp(`${spec.args.arg.name}`));
     expect(input).toHaveAttribute('type', 'text');
     expect(await findByText('Browse')).toBeInTheDocument();
-    fireEvent.change(input, { target: { value: 'foo' } });
-    await waitFor(() => {
-      expect(input).toHaveValue('foo');
-      expect(input.classList.contains('is-invalid')).toBeTruthy();
-    });
-    expect(await findByText(validationMessage, { exact: false }))
-      .toBeInTheDocument();
   });
 
   test('expect a text input for a raster', async () => {
-    const spec = {
-      args: {
-        arg: {
-          name: 'foo',
-          type: 'raster',
-        },
-      },
-    };
-    fetchValidation.mockResolvedValue(
-      [[Object.keys(spec.args), validationMessage]]
-    );
+    spec.args.arg.type = 'raster';
     const { findByText, findByLabelText } = renderSetupFromSpec(spec);
+
     const input = await findByLabelText(RegExp(`${spec.args.arg.name}`));
     expect(input).toHaveAttribute('type', 'text');
     expect(await findByText('Browse')).toBeInTheDocument();
-    fireEvent.change(input, { target: { value: 'foo' } });
-    await waitFor(() => {
-      expect(input).toHaveValue('foo');
-      expect(input.classList.contains('is-invalid')).toBeTruthy();
-    });
-    expect(await findByText(validationMessage, { exact: false }))
-      .toBeInTheDocument();
   });
 
   test('expect a text input for a freestyle_string', async () => {
@@ -182,60 +105,21 @@ describe('Arguments form input types', () => {
     // a PureComponent for ArgsForm. PureComponents check for shallow-equality
     // of props and avoid re-rendering if equal. This test alone maintained
     // shallow-equality in a case where we definitely do need to re-render.
-    const spec = {
-      args: {
-        arg: {
-          name: 'foo',
-          type: 'freestyle_string',
-        },
-      },
-    };
-    fetchValidation.mockResolvedValue([]);
+    spec.args.arg.type = 'freestyle_string';
     const { findByLabelText } = renderSetupFromSpec(spec);
     const input = await findByLabelText(RegExp(`${spec.args.arg.name}`));
     expect(input).toHaveAttribute('type', 'text');
-    fireEvent.change(input, { target: { value: 'foo' } });
-    await waitFor(() => {
-      expect(input).toHaveValue('foo');
-      // Not really possible to invalidate a freestyle_string
-      expect(input.classList.contains('is-invalid')).toBeFalsy();
-    });
   });
 
   test('expect a text input for a number', async () => {
-    const spec = {
-      args: {
-        arg: {
-          name: 'foo',
-          type: 'number',
-        },
-      },
-    };
-    fetchValidation.mockResolvedValue(
-      [[Object.keys(spec.args), validationMessage]]
-    );
-    const { findByText, findByLabelText } = renderSetupFromSpec(spec);
+    spec.args.arg.type = 'number';
+    const { findByLabelText } = renderSetupFromSpec(spec);
     const input = await findByLabelText(RegExp(`${spec.args.arg.name}`));
     expect(input).toHaveAttribute('type', 'text');
-    fireEvent.change(input, { target: { value: 'foo' } });
-    await waitFor(() => {
-      expect(input).toHaveValue('foo');
-      expect(input.classList.contains('is-invalid')).toBeTruthy();
-    });
-    expect(await findByText(validationMessage, { exact: false }))
-      .toBeInTheDocument();
   });
 
   test('expect a radio button for a boolean', async () => {
-    const spec = {
-      args: {
-        arg: {
-          name: 'foo',
-          type: 'boolean',
-        },
-      },
-    };
-    fetchValidation.mockResolvedValue([]);
+    spec.args.arg.type = 'boolean';
     const { findByLabelText } = renderSetupFromSpec(spec);
     const input = await findByLabelText(RegExp(`${spec.args.arg.name}`));
     expect(input).toHaveAttribute('type', 'radio');
@@ -243,22 +127,135 @@ describe('Arguments form input types', () => {
   });
 
   test('expect a select input for an option_string', async () => {
-    const spec = {
-      args: {
-        arg: {
-          name: 'foo',
-          type: 'option_string',
-          validation_options: {
-            options: ['a', 'b'],
-          },
-        },
-      },
+    spec.args.arg.type = 'option_string';
+    spec.args.arg.validation_options = {
+      options: ['a', 'b']
     };
-    fetchValidation.mockResolvedValue([]);
     const { findByLabelText } = renderSetupFromSpec(spec);
     const input = await findByLabelText(RegExp(`${spec.args.arg.name}`));
     expect(input).toHaveValue('a');
     expect(input).not.toHaveValue('b');
+  });
+
+  test('expect the info dialog contains text about input', async () => {
+    spec.args.arg.type = 'directory';
+    const { findByText } = renderSetupFromSpec(spec);
+    fireEvent.click(await findByText('i'));
+    expect(await findByText(spec.args.arg.about)).toBeInTheDocument();
+  });
+});
+
+describe('Arguments form interactions', () => {
+  const validationMessage = 'invalid because';
+  let spec;
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  beforeEach(() => {
+    spec = {
+      args: {
+        arg: {
+          name: 'foo',
+          type: undefined, // varies by test
+          required: undefined,
+          about: 'this is about foo',
+        },
+      },
+    };
+    fetchValidation.mockResolvedValue(
+      [[Object.keys(spec.args), validationMessage]]
+    );
+  });
+
+  test('Browse button populates an input', async () => {
+    spec.args.arg.type = 'csv';
+    const { findByText, findByLabelText } = renderSetupFromSpec(spec);
+
+    const input = await findByLabelText(RegExp(`${spec.args.arg.name}`));
+    expect(input).toHaveAttribute('type', 'text');
+    expect(await findByText('Browse')).toBeInTheDocument();
+
+    // Browsing for a file
+    const filepath = 'grilled_cheese.csv';
+    let mockDialogData = { filePaths: [filepath] };
+    remote.dialog.showOpenDialog.mockResolvedValue(mockDialogData);
+    fireEvent.click(await findByText('Browse'));
+    await waitFor(() => {
+      expect(input).toHaveValue(filepath);
+    });
+
+    // Browse again, but cancel it and expect the previous value
+    mockDialogData = { filePaths: [] }; // empty array is a mocked 'Cancel'
+    remote.dialog.showOpenDialog.mockResolvedValue(mockDialogData);
+    fireEvent.click(await findByText('Browse'));
+    await waitFor(() => {
+      expect(input).toHaveValue(filepath);
+    });
+  });
+
+  test('Change value & get feedback on a required input', async () => {
+    spec.args.arg.type = 'directory';
+    spec.args.arg.required = true;
+    const { findByText, findByLabelText, queryByText } = renderSetupFromSpec(spec);
+
+    const input = await findByLabelText(RegExp(`${spec.args.arg.name}`));
+
+    // A required input with no value is invalid (red X), but
+    // feedback does not display until the input has been touched.
+    expect(input).toHaveClass('is-invalid');
+    expect(queryByText(RegExp(validationMessage))).toBeNull();
+
+    fireEvent.change(input, { target: { value: 'foo' } });
+    await waitFor(() => {
+      expect(input).toHaveValue('foo');
+      expect(input).toHaveClass('is-invalid');
+    });
+    expect(await findByText(RegExp(validationMessage)))
+      .toBeInTheDocument();
+
+    fetchValidation.mockResolvedValue([]); // now make input valid
+    fireEvent.change(input, { target: { value: 'mydir' } });
+    await waitFor(() => {
+      expect(input).toHaveClass('is-valid');
+      expect(queryByText(RegExp(validationMessage))).toBeNull();
+    });
+  });
+
+  test('Focus on required input & get validation feedback', async () => {
+    spec.args.arg.type = 'csv';
+    spec.args.arg.required = true;
+    const { findByText, findByLabelText, queryByText } = renderSetupFromSpec(spec);
+
+    const input = await findByLabelText(RegExp(`${spec.args.arg.name}`));
+    expect(input).toHaveClass('is-invalid');
+    expect(queryByText(RegExp(validationMessage))).toBeNull();
+
+    await fireEvent.focus(input);
+    await waitFor(() => {
+      expect(input).toHaveClass('is-invalid');
+    });
+    expect(await findByText(RegExp(validationMessage)))
+      .toBeInTheDocument();
+  });
+
+  test('Focus on optional input & get valid display', async () => {
+    spec.args.arg.type = 'csv';
+    spec.args.arg.required = false;
+    fetchValidation.mockResolvedValue([]);
+    const { findByLabelText } = renderSetupFromSpec(spec);
+
+    const input = await findByLabelText(RegExp(`${spec.args.arg.name}`));
+
+    // An optional input with no value is valid, but green check
+    // does not display until the input has been touched.
+    expect(input).not.toHaveClass('is-valid', 'is-invalid');
+
+    await fireEvent.focus(input);
+    await waitFor(() => {
+      expect(input).toHaveClass('is-valid');
+    });
   });
 });
 
@@ -271,7 +268,7 @@ describe('UI spec functionality', () => {
     jest.resetAllMocks();
   });
 
-  test('test a UI spec with a boolean controller arg', async () => {
+  test('A UI spec with a boolean controller arg', async () => {
     const spec = {
       module: 'natcap.invest.dummy',
       args: {
@@ -402,7 +399,7 @@ describe('UI spec functionality', () => {
     });
   });
 
-  test('test grouping and sorting of args', async () => {
+  test('Grouping and sorting of args', async () => {
     const spec = {
       module: 'natcap.invest.dummy',
       args: {
@@ -464,7 +461,7 @@ describe('UI spec functionality', () => {
   });
 });
 
-test('SetupTab: test validation payload is well-formatted', async () => {
+test('Validation payload is well-formatted', async () => {
   const spec = {
     args: {
       a: {
@@ -494,7 +491,6 @@ test('SetupTab: test validation payload is well-formatted', async () => {
     const payload = fetchValidation.mock.results[0].value;
     expectedKeys.forEach((key) => {
       expect(Object.keys(payload)).toContain(key);
-      // expect(Object.keys(payload).includes(key)).toBe(true);
     });
   });
   fetchValidation.mockReset();


### PR DESCRIPTION
This Fixes #66 and #61 

Invest validation results are displayed as follows:
* If form is loaded with initial inputs (from datastack/logfile or recent job) all validation feedback is displayed on all inputs immediately
* If a blank setup form is loaded for a model:
  + Validation runs and :x: is displayed, next to invalid inputs. With no values yet entered, required inputs will be invalid, optional inputs will be valid. This fixes #66 .
  + The feedback message for a field only appears once the field has been touched (either a 'change' or a 'focus'). Similarly, the :heavy_check_mark: does not appear on optional inputs until they are touched.

This is a compromise between not overloading the UI with validation feedback immediately when the blank form is loaded, but still differentiating between required & optional inputs so it's always clear which input(s) still need to go valid in order to enable the Run button.

For #61, the Bounding Box feedback message is formatted like this. Each input only reports on it's own bounding box. And the boxes are arranged with fixed-width to help with comparing the boxes and finding the one(s) that don't match the others.
![Screenshot from 2020-11-18 05-39-37](https://user-images.githubusercontent.com/4071255/99537409-7c10b100-2960-11eb-82f1-ba851e7b933b.png)
