### PR TITLE
Avoid port conflicts

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -2,10 +2,11 @@
 # to customize the linkage to the python side of this application
 # by defining custom paths to the invest and server executeables.
 
-# USAGE: Create a `.env` file in the project root that looks similar to this one. This file is loaded by main.js if it is launched in dev mode. 
+# USAGE: Create a `.env` file in the project root that looks similar to this
+# one. This file is loaded by main.js if it is launched in dev mode. 
 
 # Use-case 1. PyInstaller-built invest binaries in some custom location.
-# leave off extensions - the app will add ".exe" if it detects Windows.
+# Add extensions, such as ".exe" if on Windows.
 INVEST="build/invest/invest"
 SERVER="build/invest/server"
 

--- a/invest-flask.spec
+++ b/invest-flask.spec
@@ -64,11 +64,6 @@ else:
         ('msvcr90.dll', 'C:\\Windows\\System32\\msvcr90.dll', 'BINARY')
     ]
 
-    # add rtree dependency dynamic libraries from conda environment
-#    invest_a.binaries += [
-#        (os.path.basename(name), name, 'BINARY') for name in
-#        glob.glob(os.path.join(conda_env, 'Library/bin/spatialindex*.dll'))]
-
     # .exe extension is required if we're on windows.
     invest_exename += '.exe'
     server_exename += '.exe'

--- a/invest-flask.spec
+++ b/invest-flask.spec
@@ -6,9 +6,9 @@ import itertools
 import glob
 from PyInstaller.compat import is_win, is_darwin, is_linux
 
-#if not is_win:
-# Windows builds on Actions don't use conda
-conda_env = os.environ['CONDA_PREFIX']
+if not is_win:
+    # Windows builds on Actions don't use conda
+    conda_env = os.environ['CONDA_PREFIX']
 workbench_dir = os.getcwd()
 invest_dir = os.path.join(workbench_dir, 'invest')
 block_cipher = None
@@ -63,11 +63,11 @@ else:
         ('msvcp90.dll', 'C:\\Windows\\System32\\msvcp90.dll', 'BINARY'),
         ('msvcr90.dll', 'C:\\Windows\\System32\\msvcr90.dll', 'BINARY')
     ]
-    
+
     # add rtree dependency dynamic libraries from conda environment
-    invest_a.binaries += [
-        (os.path.basename(name), name, 'BINARY') for name in
-        glob.glob(os.path.join(conda_env, 'Library/bin/spatialindex*.dll'))]
+#    invest_a.binaries += [
+#        (os.path.basename(name), name, 'BINARY') for name in
+#        glob.glob(os.path.join(conda_env, 'Library/bin/spatialindex*.dll'))]
 
     # .exe extension is required if we're on windows.
     invest_exename += '.exe'

--- a/invest-flask.spec
+++ b/invest-flask.spec
@@ -6,9 +6,9 @@ import itertools
 import glob
 from PyInstaller.compat import is_win, is_darwin, is_linux
 
-if not is_win:
-    # Windows builds on Actions don't use conda
-    conda_env = os.environ['CONDA_PREFIX']
+#if not is_win:
+# Windows builds on Actions don't use conda
+conda_env = os.environ['CONDA_PREFIX']
 workbench_dir = os.getcwd()
 invest_dir = os.path.join(workbench_dir, 'invest')
 block_cipher = None
@@ -63,6 +63,11 @@ else:
         ('msvcp90.dll', 'C:\\Windows\\System32\\msvcp90.dll', 'BINARY'),
         ('msvcr90.dll', 'C:\\Windows\\System32\\msvcr90.dll', 'BINARY')
     ]
+    
+    # add rtree dependency dynamic libraries from conda environment
+    invest_a.binaries += [
+        (os.path.basename(name), name, 'BINARY') for name in
+        glob.glob(os.path.join(conda_env, 'Library/bin/spatialindex*.dll'))]
 
     # .exe extension is required if we're on windows.
     invest_exename += '.exe'

--- a/src/main.js
+++ b/src/main.js
@@ -8,13 +8,13 @@ if (isDevMode) {
 }
 
 const {
-  app, BrowserWindow, ipcMain, screen, nativeTheme
+  app, BrowserWindow, ipcMain, screen, nativeTheme,
 } = require('electron'); // eslint-disable-line import/no-extraneous-dependencies
 const {
-  getFlaskIsReady, shutdownPythonProcess
+  getFlaskIsReady, shutdownPythonProcess,
 } = require('./server_requests');
 const {
-  findInvestBinaries, createPythonFlaskProcess
+  findInvestBinaries, createPythonFlaskProcess,
 } = require('./main_helpers');
 const { getLogger } = require('./logger');
 
@@ -34,9 +34,9 @@ const createWindow = async () => {
     event.reply('variable-reply', mainProcessVars);
   });
 
-  // Wait for a response from the server confirming the host information
+  // Wait for a response from python server confirming the host information
   await createPythonFlaskProcess(binaries.server, isDevMode);
-  // Wait for a response from the server before loading the app
+  // Wait for the python server to finish startup before loading the app
   await getFlaskIsReady();
 
   // always use light mode regardless of the OS/browser setting
@@ -66,7 +66,7 @@ const createWindow = async () => {
   mainWindow.webContents.on('did-frame-finish-load', async () => {
     if (isDevMode) {
       const {
-        default: installExtension, REACT_DEVELOPER_TOOLS
+        default: installExtension, REACT_DEVELOPER_TOOLS,
       } = require('electron-devtools-installer');
       await installExtension(REACT_DEVELOPER_TOOLS);
       mainWindow.webContents.openDevTools();

--- a/src/main.js
+++ b/src/main.js
@@ -35,7 +35,13 @@ const createWindow = async () => {
   });
 
   // Wait for a response from python server confirming the host information
-  await createPythonFlaskProcess(binaries.server, isDevMode);
+  const port = await createPythonFlaskProcess(binaries.server, isDevMode);
+  if (port !== 'undefined') {
+    process.env['PORT'] = int(port);
+  }
+  else {
+    logger.error('The resolving of the server port timed out. Try again.');
+  }
   // Wait for the python server to finish startup before loading the app
   await getFlaskIsReady();
 

--- a/src/main.js
+++ b/src/main.js
@@ -34,7 +34,8 @@ const createWindow = async () => {
     event.reply('variable-reply', mainProcessVars);
   });
 
-  createPythonFlaskProcess(binaries.server, isDevMode);
+  // Wait for a response from the server confirming the host information
+  await createPythonFlaskProcess(binaries.server, isDevMode);
   // Wait for a response from the server before loading the app
   await getFlaskIsReady();
 

--- a/src/main.js
+++ b/src/main.js
@@ -20,8 +20,6 @@ const { getLogger } = require('./logger');
 
 const logger = getLogger(__filename.split('/').slice(-1)[0]);
 
-const PORT = (process.env.PORT || '5000').trim();
-
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.
 let mainWindow;

--- a/src/main.js
+++ b/src/main.js
@@ -37,7 +37,7 @@ const createWindow = async () => {
   // Wait for a response from python server confirming the host information
   const port = await createPythonFlaskProcess(binaries.server, isDevMode);
   if (port !== 'undefined') {
-    process.env['PORT'] = int(port);
+    process.env['PORT'] = parseInt(port);
   }
   else {
     logger.error('The resolving of the server port timed out. Try again.');

--- a/src/main_helpers.js
+++ b/src/main_helpers.js
@@ -119,7 +119,7 @@ export async function createPythonFlaskProcess(serverExe, isDevMode) {
       await new Promise((resolve) => setTimeout(resolve, 500));
       logger.debug(`Waiting for Port confirmation: retry # ${i}`);
     }
-    resolve(flaskPort || 'undefined');
+    return flaskPort || 'undefined';
   } else {
     logger.error('no existing invest installations found');
   }

--- a/src/main_helpers.js
+++ b/src/main_helpers.js
@@ -61,55 +61,64 @@ export function findInvestBinaries(isDevMode) {
  * @param {boolean} isDevMode - a boolean designating dev mode or not.
  * @returns {undefined}
  */
-export function createPythonFlaskProcess(serverExe, isDevMode) {
-  if (serverExe) {
-    var oldVar = process.env.MYVAR;
-    logger.debug(`oldVar is ${oldVar}`);
-    let pythonServerProcess;
-    if (isDevMode && process.env.PYTHON && serverExe.endsWith('.py')) {
-      // A special devMode case for launching from the source code
-      // to facilitate debugging & development of src/server.py
-      //pythonServerProcess = spawn(process.env.PYTHON, [serverExe]);
-      pythonServerProcess = spawn(process.env.PYTHON, [serverExe], {
-        env: { MYVAR: process.env.MYVAR },
+export async function createPythonFlaskProcess(serverExe, isDevMode) {
+  var isPort = false;
+    if (serverExe) {
+      let pythonServerProcess;
+      if (isDevMode && process.env.PYTHON && serverExe.endsWith('.py')) {
+        // A special devMode case for launching from the source code
+        // to facilitate debugging & development of src/server.py
+        var port = `${process.env.PORT || '5000'}`;
+        pythonServerProcess = spawn(
+          process.env.PYTHON, [serverExe, `--port=${port}`]
+        );
+      } else {
+        // The most reliable, cross-platform way to make sure spawn
+        // can find the exe is to pass only the command name while
+        // also putting it's location on the PATH:
+        pythonServerProcess = spawn(path.basename(serverExe), {
+          env: { PATH: path.dirname(serverExe) },
+        });
+      }
+
+      logger.debug(`Started python process as PID ${pythonServerProcess.pid}`);
+      logger.debug(serverExe);
+      pythonServerProcess.stdout.on('data', (data) => {
+        logger.debug(`${data}`);
+        let strData = `${data}`;
+        isPort = strData.includes('PORT');
+        if (isPort) {
+            let idx = strData.indexOf('PORT');
+            let flaskPort = strData.slice(idx+5, idx+9);
+            logger.debug(`Flask Server started on Port ${flaskPort}`);
+            process.env['PORT'] = flaskPort;
+        }
+      });
+      pythonServerProcess.stderr.on('data', (data) => {
+        logger.debug(`${data}`);
+      });
+      pythonServerProcess.on('error', (err) => {
+        logger.error(err.stack);
+        logger.error(
+          `The flask app ${serverExe} crashed or failed to start
+           so this application must be restarted`
+        );
+        throw err;
+      });
+      pythonServerProcess.on('close', (code, signal) => {
+        logger.debug(`Flask process terminated with code ${code} and signal ${signal}`);
       });
     } else {
-      // The most reliable, cross-platform way to make sure spawn
-      // can find the exe is to pass only the command name while
-      // also putting it's location on the PATH:
-      pythonServerProcess = spawn(path.basename(serverExe), {
-        env: { PATH: path.dirname(serverExe) },
-      });
+      logger.error('no existing invest installations found');
     }
 
-    logger.debug(`Started python process as PID ${pythonServerProcess.pid}`);
-    logger.debug(serverExe);
-    pythonServerProcess.stdout.on('data', (data) => {
-      logger.debug(`${data}`);
-      let strData = `${data}`;
-      let isPort = strData.includes('PORT');
-      if (isPort) {
-        let idx = strData.indexOf('PORT');
-        let flaskPort = strData.slice(idx+5, idx+9); 
-        logger.debug(`4 Flask Port ##${flaskPort}##`);
-        process.env['PORT'] = flaskPort;
-      }
-    });
-    pythonServerProcess.stderr.on('data', (data) => {
-      logger.debug(`${data}`);
-    });
-    pythonServerProcess.on('error', (err) => {
-      logger.error(err.stack);
-      logger.error(
-        `The flask app ${serverExe} crashed or failed to start
-         so this application must be restarted`
-      );
-      throw err;
-    });
-    pythonServerProcess.on('close', (code, signal) => {
-      logger.debug(`Flask process terminated with code ${code} and signal ${signal}`);
-    });
-  } else {
-    logger.error('no existing invest installations found');
-  }
+    let i = 0;
+    let serverPortRetries = 20;
+    while (i < serverPortRetries) {
+      if (isPort) break;
+      i++;
+      // Try every X ms, usually takes a couple seconds to startup.
+      await new Promise((resolve) => setTimeout(resolve, 500));
+      logger.debug(`Waiting for Port confirmation: retry # ${i}`);
+    }
 }

--- a/src/main_helpers.js
+++ b/src/main_helpers.js
@@ -62,6 +62,7 @@ export function findInvestBinaries(isDevMode) {
  */
 export async function createPythonFlaskProcess(serverExe, isDevMode) {
   let isPort = false;
+  let flaskPort;
   if (serverExe) {
     let pythonServerProcess;
     if (isDevMode && process.env.PYTHON && serverExe.endsWith('.py')) {
@@ -90,9 +91,8 @@ export async function createPythonFlaskProcess(serverExe, isDevMode) {
       isPort = strData.includes('PORT');
       if (isPort) {
         const idx = strData.indexOf('PORT');
-        const flaskPort = strData.slice(idx + 5, idx + 9);
+        flaskPort = strData.slice(idx + 5, idx + 9);
         logger.debug(`Flask Server started on Port ${flaskPort}`);
-        process.env['PORT'] = flaskPort;
       }
     });
     pythonServerProcess.stderr.on('data', (data) => {
@@ -119,6 +119,7 @@ export async function createPythonFlaskProcess(serverExe, isDevMode) {
       await new Promise((resolve) => setTimeout(resolve, 500));
       logger.debug(`Waiting for Port confirmation: retry # ${i}`);
     }
+    resolve(flaskPort || 'undefined');
   } else {
     logger.error('no existing invest installations found');
   }

--- a/src/main_helpers.js
+++ b/src/main_helpers.js
@@ -12,7 +12,7 @@ const logger = getLogger(__filename.split('/').slice(-1)[0]);
  * @returns {Promise} Resolves object with filepaths to invest binaries
  */
 export function findInvestBinaries(isDevMode) {
-  return new Promise(resolve => {
+  return new Promise((resolve) => {
     // Binding to the invest server binary:
     let serverExe;
     let investExe;
@@ -63,62 +63,62 @@ export function findInvestBinaries(isDevMode) {
  */
 export async function createPythonFlaskProcess(serverExe, isDevMode) {
   var isPort = false;
-    if (serverExe) {
-      let pythonServerProcess;
-      if (isDevMode && process.env.PYTHON && serverExe.endsWith('.py')) {
-        // A special devMode case for launching from the source code
-        // to facilitate debugging & development of src/server.py
-        var port = `${process.env.PORT || '5000'}`;
-        pythonServerProcess = spawn(
-          process.env.PYTHON, [serverExe, `--port=${port}`]
-        );
-      } else {
-        // The most reliable, cross-platform way to make sure spawn
-        // can find the exe is to pass only the command name while
-        // also putting it's location on the PATH:
-        pythonServerProcess = spawn(path.basename(serverExe), {
-          env: { PATH: path.dirname(serverExe) },
-        });
-      }
-
-      logger.debug(`Started python process as PID ${pythonServerProcess.pid}`);
-      logger.debug(serverExe);
-      pythonServerProcess.stdout.on('data', (data) => {
-        logger.debug(`${data}`);
-        let strData = `${data}`;
-        isPort = strData.includes('PORT');
-        if (isPort) {
-            let idx = strData.indexOf('PORT');
-            let flaskPort = strData.slice(idx+5, idx+9);
-            logger.debug(`Flask Server started on Port ${flaskPort}`);
-            process.env['PORT'] = flaskPort;
-        }
-      });
-      pythonServerProcess.stderr.on('data', (data) => {
-        logger.debug(`${data}`);
-      });
-      pythonServerProcess.on('error', (err) => {
-        logger.error(err.stack);
-        logger.error(
-          `The flask app ${serverExe} crashed or failed to start
-           so this application must be restarted`
-        );
-        throw err;
-      });
-      pythonServerProcess.on('close', (code, signal) => {
-        logger.debug(`Flask process terminated with code ${code} and signal ${signal}`);
-      });
+  if (serverExe) {
+    let pythonServerProcess;
+    if (isDevMode && process.env.PYTHON && serverExe.endsWith('.py')) {
+      // A special devMode case for launching from the source code
+      // to facilitate debugging & development of src/server.py
+      const port = `${process.env.PORT || '5000'}`;
+      pythonServerProcess = spawn(
+        process.env.PYTHON, [serverExe, `--port=${port}`]
+      );
     } else {
-      logger.error('no existing invest installations found');
+      // The most reliable, cross-platform way to make sure spawn
+      // can find the exe is to pass only the command name while
+      // also putting it's location on the PATH:
+      pythonServerProcess = spawn(path.basename(serverExe), {
+        env: { PATH: path.dirname(serverExe) },
+      });
     }
 
-    let i = 0;
-    let serverPortRetries = 20;
-    while (i < serverPortRetries) {
-      if (isPort) break;
-      i++;
-      // Try every X ms, usually takes a couple seconds to startup.
-      await new Promise((resolve) => setTimeout(resolve, 500));
-      logger.debug(`Waiting for Port confirmation: retry # ${i}`);
-    }
+    logger.debug(`Started python process as PID ${pythonServerProcess.pid}`);
+    logger.debug(serverExe);
+    pythonServerProcess.stdout.on('data', (data) => {
+      logger.debug(`${data}`);
+      const strData = `${data}`;
+      isPort = strData.includes('PORT');
+      if (isPort) {
+        const idx = strData.indexOf('PORT');
+        const flaskPort = strData.slice(idx + 5, idx + 9);
+        logger.debug(`Flask Server started on Port ${flaskPort}`);
+        process.env['PORT'] = flaskPort;
+      }
+    });
+    pythonServerProcess.stderr.on('data', (data) => {
+      logger.debug(`${data}`);
+    });
+    pythonServerProcess.on('error', (err) => {
+      logger.error(err.stack);
+      logger.error(
+        `The flask app ${serverExe} crashed or failed to start
+         so this application must be restarted`
+      );
+      throw err;
+    });
+    pythonServerProcess.on('close', (code, signal) => {
+      logger.debug(`Flask process terminated with code ${code} and signal ${signal}`);
+    });
+  } else {
+    logger.error('no existing invest installations found');
+  }
+
+  let i = 0;
+  const serverPortRetries = 20;
+  while (i < serverPortRetries) {
+    if (isPort) break;
+    i++;
+    // Try every X ms, usually takes a couple seconds to startup.
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    logger.debug(`Waiting for Port confirmation: retry # ${i}`);
+  }
 }

--- a/src/main_helpers.js
+++ b/src/main_helpers.js
@@ -32,9 +32,8 @@ export function findInvestBinaries(isDevMode) {
     } else if (isDevMode) {
       // If no dotenv vars are set, default to where this project's
       // build process places the binaries.
-      serverExe = `${process.env.SERVER || 'build/invest/server'}${ext}`;
-      //serverExe = `${process.env.SERVER || 'build/invest/server'}`;
-      investExe = `${process.env.INVEST || 'build/invest/invest'}${ext}`;
+      serverExe = `${process.env.SERVER}` || `'build/invest/server'${ext}`;
+      investExe = `${process.env.INVEST}` || `'build/invest/invest'${ext}`;
 
     // C) point to binaries included in this app's installation.
     } else {

--- a/src/main_helpers.js
+++ b/src/main_helpers.js
@@ -58,9 +58,13 @@ export function findInvestBinaries(isDevMode) {
  *
  * @param  {string} serverExe - path to executeable that launches flask app.
  * @param {boolean} isDevMode - a boolean designating dev mode or not.
- * @returns {undefined}
+ * @param {number} serverPortRetries - the number of retries for awaiting the
+ *  server to report which port it used.
+ * @returns {Promise} Returns port number or 'undefined' if no port was
+ *  reported.
  */
-export async function createPythonFlaskProcess(serverExe, isDevMode) {
+export async function createPythonFlaskProcess(
+  serverExe, isDevMode, { serverPortRetries = 20 } = {}) {
   let isPort = false;
   let flaskPort;
   if (serverExe) {
@@ -111,7 +115,6 @@ export async function createPythonFlaskProcess(serverExe, isDevMode) {
     });
 
     let i = 0;
-    const serverPortRetries = 20;
     while (i < serverPortRetries) {
       if (isPort) break;
       i++;
@@ -119,9 +122,8 @@ export async function createPythonFlaskProcess(serverExe, isDevMode) {
       await new Promise((resolve) => setTimeout(resolve, 500));
       logger.debug(`Waiting for Port confirmation: retry # ${i}`);
     }
-    return flaskPort || 'undefined';
   } else {
     logger.error('no existing invest installations found');
   }
-
+  return flaskPort || 'undefined';
 }

--- a/src/main_helpers.js
+++ b/src/main_helpers.js
@@ -32,8 +32,8 @@ export function findInvestBinaries(isDevMode) {
     } else if (isDevMode) {
       // If no dotenv vars are set, default to where this project's
       // build process places the binaries.
-      //serverExe = `${process.env.SERVER || 'build/invest/server'}${ext}`;
-      serverExe = `${process.env.SERVER || 'build/invest/server'}`;
+      serverExe = `${process.env.SERVER || 'build/invest/server'}${ext}`;
+      //serverExe = `${process.env.SERVER || 'build/invest/server'}`;
       investExe = `${process.env.INVEST || 'build/invest/invest'}${ext}`;
 
     // C) point to binaries included in this app's installation.

--- a/src/server.py
+++ b/src/server.py
@@ -1,3 +1,5 @@
+import os
+import socket
 import codecs
 import collections
 from datetime import datetime
@@ -6,6 +8,7 @@ import json
 import logging
 import pprint
 import textwrap
+import argparse
 
 from flask import Flask
 from flask import request
@@ -209,4 +212,25 @@ def save_to_python():
 
 if __name__ == '__main__':
     print('Running Flask App')
-    app.run()
+#    parser = argparse.ArgumentParser()
+#    parser.add_argument("--port", help="The port number of the Flask Server.")
+#    args = parser.parse_args()
+#    port = args.get('FLASK_RUN_PORT', 5002)
+#    print('PORT IS : ', port)
+
+#    try:
+#        print('TRYING SOCKET BIND')
+#        serversocket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+#        serversocket.bind(('localhost', port))
+#        serversocket.listen(5)
+#        serversocket.shutdown(socket.SHUT_RDWR)
+#        serversocket.close()
+#        break
+#    except OSError as err:
+#        port = port + 1
+#        print("OSError: ", err)
+
+    
+    print('PORT 5002')
+    app.run(port=5002)
+

--- a/src/server.py
+++ b/src/server.py
@@ -8,6 +8,7 @@ import json
 import logging
 import pprint
 import socket
+import sys
 import textwrap
 
 from flask import Flask
@@ -220,8 +221,10 @@ if __name__ == '__main__':
     parser.add_argument(
         "--flex", default=True, help="The port number of the Flask Server.")
     args = vars(parser.parse_args())
-    port = int(args.get('port', 5000))
-    flex = bool(args.get('flex', True))
+    # Since port and flex are optional arguments with defaults, they should
+    # always be keys
+    port = int(args['port'])
+    flex = bool(args['flex'])
 
     port_good = False
     # Number of ports to increment for attempts
@@ -244,6 +247,6 @@ if __name__ == '__main__':
         port = port + 1
 
     # Write to stdout so that parent process can receive the used port number
-    print(f'PORT {port}')
-    app.run(port=int(port))
+    sys.stdout.write(f'PORT {port}')
+    app.run(port=port)
 

--- a/src/server.py
+++ b/src/server.py
@@ -216,7 +216,7 @@ if __name__ == '__main__':
     # try other ports if the current one is already in use
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "--port", help="The port number of the Flask Server.")
+        "--port", default=5000, help="The port number of the Flask Server.")
     parser.add_argument(
         "--flex", default=True, help="The port number of the Flask Server.")
     args = vars(parser.parse_args())

--- a/src/server_requests.js
+++ b/src/server_requests.js
@@ -4,7 +4,6 @@ import { getLogger } from './logger';
 const logger = getLogger(__filename.split('/').slice(-1)[0]);
 const HOSTNAME = 'http://localhost';
 
-
 /** Find out if the Flask server is online, waiting until it is.
  *
  * Sometimes the app will make a server request before it's ready,

--- a/src/server_requests.js
+++ b/src/server_requests.js
@@ -2,18 +2,8 @@ import fetch from 'node-fetch';
 import { getLogger } from './logger';
 
 const logger = getLogger(__filename.split('/').slice(-1)[0]);
-//const PORT = process.env.PORT || '5000';
 const HOSTNAME = 'http://localhost';
 
-/** Return the port number to expect.
- *
- * The Flask app could update the default port number which will update 
- * process.env.PORT
- *
- */
-function getFlaskPort() {
-  return process.env.PORT || '5000';
-}
 
 /** Find out if the Flask server is online, waiting until it is.
  *
@@ -26,15 +16,14 @@ function getFlaskPort() {
  */
 export function getFlaskIsReady({ i = 0, retries = 21 } = {}) {
   return (
-    fetch(`${HOSTNAME}:${getFlaskPort()}/ready`, {
+    fetch(`${HOSTNAME}:${process.env.PORT}/ready`, {
       method: 'get',
     })
-      .then((response) => response.text())
+      .then(response => response.text())
       .catch(async (error) => {
         if (error.code === 'ECONNREFUSED') {
           while (i < retries) {
-            //var testVar = process.env.MYVAR;
-            //logger.debug(`MYVAR is ${testVar}`);
+            logger.debug(`PORT is ${PORT}`);
             i++;
             // Try every X ms, usually takes a couple seconds to startup.
             await new Promise((resolve) => setTimeout(resolve, 300));
@@ -59,7 +48,7 @@ export function getFlaskIsReady({ i = 0, retries = 21 } = {}) {
  */
 export function getInvestList() {
   return (
-    fetch(`${HOSTNAME}:${getFlaskPort()}/models`, {
+    fetch(`${HOSTNAME}:${process.env.PORT}/models`, {
       method: 'get',
     })
       .then((response) => response.json())
@@ -75,7 +64,7 @@ export function getInvestList() {
  */
 export function getSpec(payload) {
   return (
-    fetch(`${HOSTNAME}:${getFlaskPort()}/getspec`, {
+    fetch(`${HOSTNAME}:${process.env.PORT}/getspec`, {
       method: 'post',
       body: JSON.stringify(payload),
       headers: { 'Content-Type': 'application/json' },
@@ -96,7 +85,7 @@ export function getSpec(payload) {
  */
 export function fetchValidation(payload) {
   return (
-    fetch(`${HOSTNAME}:${getFlaskPort()}/validate`, {
+    fetch(`${HOSTNAME}:${process.env.PORT}/validate`, {
       method: 'post',
       body: JSON.stringify(payload),
       headers: { 'Content-Type': 'application/json' },
@@ -114,7 +103,7 @@ export function fetchValidation(payload) {
  */
 export function fetchDatastackFromFile(payload) {
   return (
-    fetch(`${HOSTNAME}:${getFlaskPort()}/post_datastack_file`, {
+    fetch(`${HOSTNAME}:${process.env.PORT}/post_datastack_file`, {
       method: 'post',
       body: JSON.stringify(payload),
       headers: { 'Content-Type': 'application/json' },
@@ -137,7 +126,7 @@ export function fetchDatastackFromFile(payload) {
  */
 export function saveToPython(payload) {
   return (
-    fetch(`${HOSTNAME}:${getFlaskPort()}/save_to_python`, {
+    fetch(`${HOSTNAME}:${process.env.PORT}/save_to_python`, {
       method: 'post',
       body: JSON.stringify(payload),
       headers: { 'Content-Type': 'application/json' },
@@ -161,7 +150,7 @@ export function saveToPython(payload) {
  */
 export function writeParametersToFile(payload) {
   return (
-    fetch(`${HOSTNAME}:${getFlaskPort()}/write_parameter_set_file`, {
+    fetch(`${HOSTNAME}:${process.env.PORT}/write_parameter_set_file`, {
       method: 'post',
       body: JSON.stringify(payload),
       headers: { 'Content-Type': 'application/json' },
@@ -179,7 +168,7 @@ export function writeParametersToFile(payload) {
  */
 export function shutdownPythonProcess() {
   return (
-    fetch(`http://localhost:${getFlaskPort()}/shutdown`, {
+    fetch(`http://localhost:${process.env.PORT}/shutdown`, {
       method: 'get',
     })
       .then((response) => response.text())

--- a/src/server_requests.js
+++ b/src/server_requests.js
@@ -23,7 +23,6 @@ export function getFlaskIsReady({ i = 0, retries = 21 } = {}) {
       .catch(async (error) => {
         if (error.code === 'ECONNREFUSED') {
           while (i < retries) {
-            logger.debug(`PORT is ${PORT}`);
             i++;
             // Try every X ms, usually takes a couple seconds to startup.
             await new Promise((resolve) => setTimeout(resolve, 300));

--- a/src/server_requests.js
+++ b/src/server_requests.js
@@ -2,8 +2,18 @@ import fetch from 'node-fetch';
 import { getLogger } from './logger';
 
 const logger = getLogger(__filename.split('/').slice(-1)[0]);
-const PORT = process.env.PORT || '5000';
+//const PORT = process.env.PORT || '5000';
 const HOSTNAME = 'http://localhost';
+
+/** Return the port number to expect.
+ *
+ * The Flask app could update the default port number which will update 
+ * process.env.PORT
+ *
+ */
+function getFlaskPort() {
+  return process.env.PORT || '5000';
+}
 
 /** Find out if the Flask server is online, waiting until it is.
  *
@@ -16,13 +26,15 @@ const HOSTNAME = 'http://localhost';
  */
 export function getFlaskIsReady({ i = 0, retries = 21 } = {}) {
   return (
-    fetch(`${HOSTNAME}:${PORT}/ready`, {
+    fetch(`${HOSTNAME}:${getFlaskPort()}/ready`, {
       method: 'get',
     })
       .then((response) => response.text())
       .catch(async (error) => {
         if (error.code === 'ECONNREFUSED') {
           while (i < retries) {
+            //var testVar = process.env.MYVAR;
+            //logger.debug(`MYVAR is ${testVar}`);
             i++;
             // Try every X ms, usually takes a couple seconds to startup.
             await new Promise((resolve) => setTimeout(resolve, 300));
@@ -47,7 +59,7 @@ export function getFlaskIsReady({ i = 0, retries = 21 } = {}) {
  */
 export function getInvestList() {
   return (
-    fetch(`${HOSTNAME}:${PORT}/models`, {
+    fetch(`${HOSTNAME}:${getFlaskPort()}/models`, {
       method: 'get',
     })
       .then((response) => response.json())
@@ -63,7 +75,7 @@ export function getInvestList() {
  */
 export function getSpec(payload) {
   return (
-    fetch(`${HOSTNAME}:${PORT}/getspec`, {
+    fetch(`${HOSTNAME}:${getFlaskPort()}/getspec`, {
       method: 'post',
       body: JSON.stringify(payload),
       headers: { 'Content-Type': 'application/json' },
@@ -84,7 +96,7 @@ export function getSpec(payload) {
  */
 export function fetchValidation(payload) {
   return (
-    fetch(`${HOSTNAME}:${PORT}/validate`, {
+    fetch(`${HOSTNAME}:${getFlaskPort()}/validate`, {
       method: 'post',
       body: JSON.stringify(payload),
       headers: { 'Content-Type': 'application/json' },
@@ -102,7 +114,7 @@ export function fetchValidation(payload) {
  */
 export function fetchDatastackFromFile(payload) {
   return (
-    fetch(`${HOSTNAME}:${PORT}/post_datastack_file`, {
+    fetch(`${HOSTNAME}:${getFlaskPort()}/post_datastack_file`, {
       method: 'post',
       body: JSON.stringify(payload),
       headers: { 'Content-Type': 'application/json' },
@@ -125,7 +137,7 @@ export function fetchDatastackFromFile(payload) {
  */
 export function saveToPython(payload) {
   return (
-    fetch(`${HOSTNAME}:${PORT}/save_to_python`, {
+    fetch(`${HOSTNAME}:${getFlaskPort()}/save_to_python`, {
       method: 'post',
       body: JSON.stringify(payload),
       headers: { 'Content-Type': 'application/json' },
@@ -149,7 +161,7 @@ export function saveToPython(payload) {
  */
 export function writeParametersToFile(payload) {
   return (
-    fetch(`${HOSTNAME}:${PORT}/write_parameter_set_file`, {
+    fetch(`${HOSTNAME}:${getFlaskPort()}/write_parameter_set_file`, {
       method: 'post',
       body: JSON.stringify(payload),
       headers: { 'Content-Type': 'application/json' },
@@ -167,7 +179,7 @@ export function writeParametersToFile(payload) {
  */
 export function shutdownPythonProcess() {
   return (
-    fetch(`http://localhost:${PORT}/shutdown`, {
+    fetch(`http://localhost:${getFlaskPort()}/shutdown`, {
       method: 'get',
     })
       .then((response) => response.text())

--- a/tests/binary_tests/flaskapp.test.js
+++ b/tests/binary_tests/flaskapp.test.js
@@ -13,7 +13,7 @@ jest.setTimeout(250000); // This test is slow in CI
 const isDevMode = true; // otherwise need to mock process.resourcesPath
 beforeAll(async () => {
   const binaries = await findInvestBinaries(isDevMode);
-  createPythonFlaskProcess(binaries.server, isDevMode);
+  const port = await createPythonFlaskProcess(binaries.server, isDevMode);
   // In the CI the flask app takes more than 10x as long to startup.
   // Especially so on macos.
   // So, allowing many retries, especially because the error

--- a/tests/binary_tests/flaskapp.test.js
+++ b/tests/binary_tests/flaskapp.test.js
@@ -13,7 +13,8 @@ jest.setTimeout(250000); // This test is slow in CI
 const isDevMode = true; // otherwise need to mock process.resourcesPath
 beforeAll(async () => {
   const binaries = await findInvestBinaries(isDevMode);
-  const port = await createPythonFlaskProcess(binaries.server, isDevMode);
+  const port = await createPythonFlaskProcess(
+    binaries.server, isDevMode, {serverPortRetries:  100});
   // In the CI the flask app takes more than 10x as long to startup.
   // Especially so on macos.
   // So, allowing many retries, especially because the error


### PR DESCRIPTION
This PR attempts to solve the problem of launching the Flask App on a port that is already in use. It does this by:

- using a Python `socket` to check if a port is available. 
- If a port is not available, it tries the next port number for `n` amount of ports. 
- The client side which spawned the Flask App gets the used port number via listening to the spawned processes `stdout`.

This does NOT solve the problem of launching multiple Workbench UIs, which Dave and I discussed should be a separate issue.
