### PR TITLE
Deploy build artifacts to GCS

### DIFF
--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -70,25 +70,6 @@ jobs:
     #     name: invest-workbench-${{ matrix.os }}
     #     path: dist/invest-workbench_*
 
-    - name: Set up Python for gsutil
-      # gsutil requires a python, which is not included on Windows
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.7
-
-    - name: Set CLOUDSDK_PYTHON env variable for Windows
-      if: matrix.os == 'windows-latest'
-      run: |
-        echo "CLOUDSDK_PYTHON=$('${{env.pythonLocation}}\python.exe')" >> $GITHUB_ENV
-
-    - name: Set up GCP
-      # Secrets not available in PR so don't use GCP.
-      if: github.event_name != 'pull_request'
-      uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
-      with:
-          version: '281.0.0'
-          service_account_key: ${{ secrets.GOOGLE_SERVICE_ACC_KEY }}
-
     - name: Set a GITHUB_ACTOR-dependent GCS target
       shell: bash
       # TODO: If this is a release, don't include the commit hash
@@ -100,9 +81,36 @@ jobs:
           || echo 'gs://natcap-dev-build-artifacts/${{ env.GITHUB_ACTOR }}' \
           )" >> $GITHUB_ENV
 
-    - name: Deploy artifacts to GCS
+    - name: Set up Python for gsutil
+      # gsutil requires a python, which is not included on Windows
+      if: matrix.os == 'windows-latest'
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+
+    - name: Set up GCP
       # Secrets not available in PR so don't use GCP.
       if: github.event_name != 'pull_request'
+      uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+      with:
+          version: '281.0.0'
+          service_account_key: ${{ secrets.GOOGLE_SERVICE_ACC_KEY }}
+
+    - name: Deploy artifacts to GCS - Windows
+      # Secrets not available in PR so don't use GCP.
+      if: github.event_name != 'pull_request'
+      if: matrix.os == 'windows-latest'
+      env:
+        CLOUDSDK_PYTHON: ${{env.pythonLocation}}\python.exe
+      run: |
+        echo "${{ env.BUCKET }}/invest-workbench/${{ env.PKG_VERSION }}_${{ env.GIT_REV }}"
+        gsutil -m cp dist/invest-workbench* \
+          "${{ env.BUCKET }}/invest-workbench/${{ env.PKG_VERSION }}_${{ env.GIT_REV }}"
+
+    - name: Deploy artifacts to GCS - not Windows
+      # Secrets not available in PR so don't use GCP.
+      if: github.event_name != 'pull_request'
+      if: matrix.os != 'windows-latest'
       run: |
         echo "${{ env.BUCKET }}/invest-workbench/${{ env.PKG_VERSION }}_${{ env.GIT_REV }}"
         gsutil -m cp dist/invest-workbench* \

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -98,8 +98,7 @@ jobs:
 
     - name: Deploy artifacts to GCS - Windows
       # Secrets not available in PR so don't use GCP.
-      if: github.event_name != 'pull_request'
-      if: matrix.os == 'windows-latest'
+      if: github.event_name != 'pull_request' && matrix.os == 'windows-latest'
       env:
         CLOUDSDK_PYTHON: ${{env.pythonLocation}}\python.exe
       run: |
@@ -109,8 +108,7 @@ jobs:
 
     - name: Deploy artifacts to GCS - not Windows
       # Secrets not available in PR so don't use GCP.
-      if: github.event_name != 'pull_request'
-      if: matrix.os != 'windows-latest'
+      if: github.event_name != 'pull_request' && matrix.os != 'windows-latest'
       run: |
         echo "${{ env.BUCKET }}/invest-workbench/${{ env.PKG_VERSION }}_${{ env.GIT_REV }}"
         gsutil -m cp dist/invest-workbench* \

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -63,12 +63,12 @@ jobs:
       with:
         run: npm run test-electron-app
     
-    # - name: Upload installer artifacts
-    #   uses: actions/upload-artifact@v2-preview
-    #   if: ${{ always() }}
-    #   with:
-    #     name: invest-workbench-${{ matrix.os }}
-    #     path: dist/invest-workbench_*
+    - name: Upload installer artifacts
+      uses: actions/upload-artifact@v2-preview
+      if: ${{ always() }}
+      with:
+        name: invest-workbench-${{ matrix.os }}
+        path: dist/invest-workbench_*
 
     - name: Set a GITHUB_ACTOR-dependent GCS target
       shell: bash
@@ -91,7 +91,7 @@ jobs:
     - name: Set up GCP
       # Secrets not available in PR so don't use GCP.
       if: github.event_name != 'pull_request'
-      uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+      uses: google-github-actions/setup-gcloud
       with:
           version: '281.0.0'
           service_account_key: ${{ secrets.GOOGLE_SERVICE_ACC_KEY }}

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -67,7 +67,7 @@ jobs:
           && echo 'gs://releases.naturalcapitalproject.org/invest-workbench/' \
           || echo 'gs://natcap-dev-build-artifacts/invest-workbench/${{ github.actor }}' \
           )" >> $GITHUB_ENV
-        echo "ARTIFACT_NAME=$(jq -r .build.artifactName package.json)" >> $GITHUB_ENV
+        echo "ARTIFACT_NAME=$(find dist/ -maxdepth 1 -type f \( -name invest-workbench_*.AppImage -o -name invest-workbench_*.exe \))" >> $GITHUB_ENV
 
     - name: Set up Python for gsutil
       # gsutil requires a python, which is not included on Windows

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -12,7 +12,7 @@ jobs:
         os: [macos-latest, windows-latest]
         node-version: [12.x]
     env:
-      ARTIFACT_NAME: $(jq -r .artifactName package.json)"
+      ARTIFACT_NAME: ${{ jq -r .build.artifactName package.json }}
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -20,19 +20,6 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-
-    - name: Get npm cache directory
-      id: npm-cache
-      run: |
-        echo "::set-output name=dir::$(npm config get cache)"
-
-    - name: Cache node modules
-      uses: actions/cache@v2
-      env:
-        cache-name: cache-node-modules
-      with:
-        path: ${{ steps.npm-cache.outputs.dir }}
-        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
     
     - name: NPM Install
       run: npm install

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -67,7 +67,6 @@ jobs:
           && echo 'gs://releases.naturalcapitalproject.org/invest-workbench/' \
           || echo 'gs://natcap-dev-build-artifacts/invest-workbench/${{ github.actor }}' \
           )" >> $GITHUB_ENV
-        echo "ARTIFACT_NAME=$(find dist/ -maxdepth 1 -type f \( -name invest-workbench_*.AppImage -o -name invest-workbench_*.exe \))" >> $GITHUB_ENV
 
     - name: Set up Python for gsutil
       # gsutil requires a python, which is not included on Windows
@@ -90,14 +89,10 @@ jobs:
       env:
         CLOUDSDK_PYTHON: ${{env.pythonLocation}}\python.exe
       run: |
-        echo "${{ env.BUCKET }}/${{ env.PKG_VERSION }}_${{ env.GIT_REV }}/${{ env.ARTIFACT_NAME }}"
-        gsutil -m cp dist/${{ env.ARTIFACT_NAME }} \
-          "${{ env.BUCKET }}/${{ env.PKG_VERSION }}_${{ env.GIT_REV }}/${{ env.ARTIFACT_NAME }}"
+        gsutil -m rsync dist/ "${{ env.BUCKET }}/${{ env.PKG_VERSION }}_${{ env.GIT_REV }}/"
 
     - name: Deploy artifacts to GCS - Not Windows
       # Secrets not available in PR so don't use GCP.
       if: github.event_name != 'pull_request' && matrix.os != 'windows-latest'
       run: |
-        echo "${{ env.BUCKET }}/${{ env.PKG_VERSION }}_${{ env.GIT_REV }}/${{ env.ARTIFACT_NAME }}"
-        gsutil -m cp dist/${{ env.ARTIFACT_NAME }} \
-          "${{ env.BUCKET }}/${{ env.PKG_VERSION }}_${{ env.GIT_REV }}/${{ env.ARTIFACT_NAME }}"
+        gsutil -m rsync dist/ "${{ env.BUCKET }}/${{ env.PKG_VERSION }}_${{ env.GIT_REV }}/"

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -57,17 +57,17 @@ jobs:
         name: invest-workbench-${{ matrix.os }}
         path: dist/invest-workbench_*
 
-    - name: Set a GITHUB_ACTOR-dependent GCS target
+    - name: Set a github.actor-dependent GCS target
       shell: bash
       # TODO: If this is a release, don't include the commit hash
       run: |
-        echo $GITHUB_ACTOR
-        echo ${{ GITHUB_ACTOR }}
+        echo github.actor
+        echo "${{ github.actor }}"
         echo "PKG_VERSION=$(jq -r .version package.json)" >> $GITHUB_ENV
         echo "GIT_REV=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
-        echo "BUCKET=$([ env.GITHUB_ACTOR == 'natcap' ] \
+        echo "BUCKET=$([ github.actor == 'natcap' ] \
           && echo 'gs://releases.naturalcapitalproject.org' \
-          || echo 'gs://natcap-dev-build-artifacts/${{ GITHUB_ACTOR }}' \
+          || echo 'gs://natcap-dev-build-artifacts/${{ github.actor }}' \
           )" >> $GITHUB_ENV
 
     - name: Set up Python for gsutil

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -71,10 +71,10 @@ jobs:
     #     path: dist/invest-workbench_*
 
     - name: Set up Python for gsutil
-        # gsutil requires a python, which is not included on Windows
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.7
+      # gsutil requires a python, which is not included on Windows
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
 
     - name: Set up GCP
       # Secrets not available in PR so don't use GCP.

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -56,3 +56,29 @@ jobs:
       with:
         name: invest-workbench-${{ matrix.os }}
         path: dist/invest-workbench_*
+
+    - name: Set up GCP
+      # Secrets not available in PR so don't use GCP.
+      if: github.event_name != 'pull_request'
+      uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+      with:
+          version: '281.0.0'
+          service_account_key: ${{ secrets.GOOGLE_SERVICE_ACC_KEY }}
+
+    - name: Set env var for deploy bucket
+      shell: bash
+      # If this is a release, don't include the commit hash
+      run: |
+        echo "GIT_REV=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+        echo "BUCKET=$([ env.GITHUB_ACTOR == 'natcap' ] \
+          && echo 'gs://releases.naturalcapitalproject.org' \
+          || echo 'gs://natcap-dev-build-artifacts/{{ env.GITHUB_ACTOR }}' \
+          )" >> $GITHUB_ENV
+
+    - name: Deploy artifacts to GCS
+      # Secrets not available in PR so don't use GCP.
+      # We only want to upload artifacts to a release object in a release.
+      if: github.event_name != 'pull_request'
+      run: |
+        echo "${{ env.BUCKET }}/invest-workbench/${{ env.VERSION }}_${{ env.GIT_REV }}"
+        gsutil -m rsync dist/invest-workbench* "${{ env.BUCKET }}/invest-workbench/${{ env.VERSION }}_${{ env.GIT_REV }}"

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -70,6 +70,12 @@ jobs:
     #     name: invest-workbench-${{ matrix.os }}
     #     path: dist/invest-workbench_*
 
+    - name: Set up Python for gsutil
+        # gsutil requires a python, which is not included on Windows
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+
     - name: Set up GCP
       # Secrets not available in PR so don't use GCP.
       if: github.event_name != 'pull_request'
@@ -78,7 +84,7 @@ jobs:
           version: '281.0.0'
           service_account_key: ${{ secrets.GOOGLE_SERVICE_ACC_KEY }}
 
-    - name: Set env var for deploy bucket
+    - name: Set a GITHUB_ACTOR-dependent GCS target
       shell: bash
       # If this is a release, don't include the commit hash
       run: |
@@ -95,4 +101,5 @@ jobs:
       if: github.event_name != 'pull_request'
       run: |
         echo "${{ env.BUCKET }}/invest-workbench/${{ env.PKG_VERSION }}_${{ env.GIT_REV }}"
-        gsutil -m cp dist/invest-workbench* "${{ env.BUCKET }}/invest-workbench/${{ env.PKG_VERSION }}_${{ env.GIT_REV }}"
+        gsutil -m cp dist/invest-workbench* \
+          "${{ env.BUCKET }}/invest-workbench/${{ env.PKG_VERSION }}_${{ env.GIT_REV }}"

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -74,6 +74,7 @@ jobs:
       shell: bash
       # TODO: If this is a release, don't include the commit hash
       run: |
+        echo env.GITHUB_ACTOR
         echo "PKG_VERSION=$(jq -r .version package.json)" >> $GITHUB_ENV
         echo "GIT_REV=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
         echo "BUCKET=$([ env.GITHUB_ACTOR == 'natcap' ] \
@@ -91,7 +92,7 @@ jobs:
     - name: Set up GCP
       # Secrets not available in PR so don't use GCP.
       if: github.event_name != 'pull_request'
-      uses: google-github-actions/setup-gcloud
+      uses: google-github-actions/setup-gcloud@master
       with:
           version: '281.0.0'
           service_account_key: ${{ secrets.GOOGLE_SERVICE_ACC_KEY }}
@@ -102,9 +103,9 @@ jobs:
       env:
         CLOUDSDK_PYTHON: ${{env.pythonLocation}}\python.exe
       run: |
-        echo "${{ env.BUCKET }}/invest-workbench/${{ env.PKG_VERSION }}_${{ env.GIT_REV }}"
+        echo "${{ env.BUCKET }}/invest-workbench/${{ env.PKG_VERSION }}_${{ env.GIT_REV }}/"
         gsutil -m cp dist/invest-workbench* \
-          "${{ env.BUCKET }}/invest-workbench/${{ env.PKG_VERSION }}_${{ env.GIT_REV }}"
+          "${{ env.BUCKET }}/invest-workbench/${{ env.PKG_VERSION }}_${{ env.GIT_REV }}/"
 
     - name: Deploy artifacts to GCS - not Windows
       # Secrets not available in PR so don't use GCP.

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -21,6 +21,19 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
 
+    - name: Get npm cache directory
+      id: npm-cache
+      run: |
+        echo "::set-output name=dir::$(npm config get cache)"
+
+    - name: Cache node modules
+      uses: actions/cache@v2
+      env:
+        cache-name: cache-node-modules
+      with:
+        path: ${{ steps.npm-cache.outputs.dir }}
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+    
     - name: NPM Install
       run: npm install
 
@@ -50,12 +63,12 @@ jobs:
       with:
         run: npm run test-electron-app
     
-    - name: Upload installer artifacts
-      uses: actions/upload-artifact@v2-preview
-      if: ${{ always() }}
-      with:
-        name: invest-workbench-${{ matrix.os }}
-        path: dist/invest-workbench_*
+    # - name: Upload installer artifacts
+    #   uses: actions/upload-artifact@v2-preview
+    #   if: ${{ always() }}
+    #   with:
+    #     name: invest-workbench-${{ matrix.os }}
+    #     path: dist/invest-workbench_*
 
     - name: Set up GCP
       # Secrets not available in PR so don't use GCP.
@@ -69,10 +82,11 @@ jobs:
       shell: bash
       # If this is a release, don't include the commit hash
       run: |
+        echo "PKG_VERSION=$(jq -r .version package.json)" >> $GITHUB_ENV
         echo "GIT_REV=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
         echo "BUCKET=$([ env.GITHUB_ACTOR == 'natcap' ] \
           && echo 'gs://releases.naturalcapitalproject.org' \
-          || echo 'gs://natcap-dev-build-artifacts/{{ env.GITHUB_ACTOR }}' \
+          || echo 'gs://natcap-dev-build-artifacts/${{ env.GITHUB_ACTOR }}' \
           )" >> $GITHUB_ENV
 
     - name: Deploy artifacts to GCS
@@ -80,5 +94,5 @@ jobs:
       # We only want to upload artifacts to a release object in a release.
       if: github.event_name != 'pull_request'
       run: |
-        echo "${{ env.BUCKET }}/invest-workbench/${{ env.VERSION }}_${{ env.GIT_REV }}"
-        gsutil -m rsync dist/invest-workbench* "${{ env.BUCKET }}/invest-workbench/${{ env.VERSION }}_${{ env.GIT_REV }}"
+        echo "${{ env.BUCKET }}/invest-workbench/${{ env.PKG_VERSION }}_${{ env.GIT_REV }}"
+        gsutil -m rsync dist/invest-workbench* "${{ env.BUCKET }}/invest-workbench/${{ env.PKG_VERSION }}_${{ env.GIT_REV }}"

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -11,6 +11,8 @@ jobs:
       matrix:
         os: [macos-latest, windows-latest]
         node-version: [12.x]
+    env:
+      ARTIFACT_NAME: $(jq -r .artifactName package.json)"
 
     steps:
     - name: Checkout repository
@@ -61,13 +63,11 @@ jobs:
       shell: bash
       # TODO: If this is a release, don't include the commit hash
       run: |
-        echo github.actor
-        echo "${{ github.actor }}"
         echo "PKG_VERSION=$(jq -r .version package.json)" >> $GITHUB_ENV
         echo "GIT_REV=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
         echo "BUCKET=$([ github.actor == 'natcap' ] \
-          && echo 'gs://releases.naturalcapitalproject.org' \
-          || echo 'gs://natcap-dev-build-artifacts/${{ github.actor }}' \
+          && echo 'gs://releases.naturalcapitalproject.org/invest-workbench/' \
+          || echo 'gs://natcap-dev-build-artifacts/invest-workbench/${{ github.actor }}' \
           )" >> $GITHUB_ENV
 
     - name: Set up Python for gsutil
@@ -91,14 +91,14 @@ jobs:
       env:
         CLOUDSDK_PYTHON: ${{env.pythonLocation}}\python.exe
       run: |
-        echo "${{ env.BUCKET }}/invest-workbench/${{ env.PKG_VERSION }}_${{ env.GIT_REV }}/"
-        gsutil -m cp dist/invest-workbench* \
-          "${{ env.BUCKET }}/invest-workbench/${{ env.PKG_VERSION }}_${{ env.GIT_REV }}/"
+        echo "${{ env.BUCKET }}/${{ env.PKG_VERSION }}_${{ env.GIT_REV }}/${{ env.ARTIFACT_NAME }}"
+        gsutil -m cp dist/${{ env.ARTIFACT_NAME }} \
+          "${{ env.BUCKET }}/${{ env.PKG_VERSION }}_${{ env.GIT_REV }}/${{ env.ARTIFACT_NAME }}"
 
     - name: Deploy artifacts to GCS - Not Windows
       # Secrets not available in PR so don't use GCP.
       if: github.event_name != 'pull_request' && matrix.os != 'windows-latest'
       run: |
-        echo "${{ env.BUCKET }}/invest-workbench/${{ env.PKG_VERSION }}_${{ env.GIT_REV }}"
-        gsutil -m cp dist/invest-workbench* \
-          "${{ env.BUCKET }}/invest-workbench/${{ env.PKG_VERSION }}_${{ env.GIT_REV }}"
+        echo "${{ env.BUCKET }}/${{ env.PKG_VERSION }}_${{ env.GIT_REV }}/${{ env.ARTIFACT_NAME }}"
+        gsutil -m cp dist/${{ env.ARTIFACT_NAME }} \
+          "${{ env.BUCKET }}/${{ env.PKG_VERSION }}_${{ env.GIT_REV }}/${{ env.ARTIFACT_NAME }}"

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -76,6 +76,11 @@ jobs:
       with:
         python-version: 3.7
 
+    - name: Set CLOUDSDK_PYTHON env variable for Windows
+      if: matrix.os == 'windows-latest'
+      run: |
+        echo "CLOUDSDK_PYTHON=$('${{env.pythonLocation}}\python.exe')" >> $GITHUB_ENV
+
     - name: Set up GCP
       # Secrets not available in PR so don't use GCP.
       if: github.event_name != 'pull_request'
@@ -86,7 +91,7 @@ jobs:
 
     - name: Set a GITHUB_ACTOR-dependent GCS target
       shell: bash
-      # If this is a release, don't include the commit hash
+      # TODO: If this is a release, don't include the commit hash
       run: |
         echo "PKG_VERSION=$(jq -r .version package.json)" >> $GITHUB_ENV
         echo "GIT_REV=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
@@ -97,7 +102,6 @@ jobs:
 
     - name: Deploy artifacts to GCS
       # Secrets not available in PR so don't use GCP.
-      # We only want to upload artifacts to a release object in a release.
       if: github.event_name != 'pull_request'
       run: |
         echo "${{ env.BUCKET }}/invest-workbench/${{ env.PKG_VERSION }}_${{ env.GIT_REV }}"

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -11,8 +11,6 @@ jobs:
       matrix:
         os: [macos-latest, windows-latest]
         node-version: [12.x]
-    env:
-      ARTIFACT_NAME: ${{ jq -r .build.artifactName package.json }}
 
     steps:
     - name: Checkout repository
@@ -59,7 +57,7 @@ jobs:
         name: invest-workbench-${{ matrix.os }}
         path: dist/invest-workbench_*
 
-    - name: Set a github.actor-dependent GCS target
+    - name: Set variables for GCS deploy target
       shell: bash
       # TODO: If this is a release, don't include the commit hash
       run: |
@@ -69,6 +67,7 @@ jobs:
           && echo 'gs://releases.naturalcapitalproject.org/invest-workbench/' \
           || echo 'gs://natcap-dev-build-artifacts/invest-workbench/${{ github.actor }}' \
           )" >> $GITHUB_ENV
+        echo "ARTIFACT_NAME=$(jq -r .build.artifactName package.json)" >> $GITHUB_ENV
 
     - name: Set up Python for gsutil
       # gsutil requires a python, which is not included on Windows

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -61,7 +61,8 @@ jobs:
       shell: bash
       # TODO: If this is a release, don't include the commit hash
       run: |
-        echo env.GITHUB_ACTOR
+        echo $env.GITHUB_ACTOR
+        echo ${{ env.GITHUB_ACTOR }}
         echo "PKG_VERSION=$(jq -r .version package.json)" >> $GITHUB_ENV
         echo "GIT_REV=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
         echo "BUCKET=$([ env.GITHUB_ACTOR == 'natcap' ] \

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -95,4 +95,4 @@ jobs:
       if: github.event_name != 'pull_request'
       run: |
         echo "${{ env.BUCKET }}/invest-workbench/${{ env.PKG_VERSION }}_${{ env.GIT_REV }}"
-        gsutil -m rsync dist/invest-workbench* "${{ env.BUCKET }}/invest-workbench/${{ env.PKG_VERSION }}_${{ env.GIT_REV }}"
+        gsutil -m cp dist/invest-workbench* "${{ env.BUCKET }}/invest-workbench/${{ env.PKG_VERSION }}_${{ env.GIT_REV }}"

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -61,13 +61,13 @@ jobs:
       shell: bash
       # TODO: If this is a release, don't include the commit hash
       run: |
-        echo $env.GITHUB_ACTOR
-        echo ${{ env.GITHUB_ACTOR }}
+        echo $GITHUB_ACTOR
+        echo ${{ GITHUB_ACTOR }}
         echo "PKG_VERSION=$(jq -r .version package.json)" >> $GITHUB_ENV
         echo "GIT_REV=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
         echo "BUCKET=$([ env.GITHUB_ACTOR == 'natcap' ] \
           && echo 'gs://releases.naturalcapitalproject.org' \
-          || echo 'gs://natcap-dev-build-artifacts/${{ env.GITHUB_ACTOR }}' \
+          || echo 'gs://natcap-dev-build-artifacts/${{ GITHUB_ACTOR }}' \
           )" >> $GITHUB_ENV
 
     - name: Set up Python for gsutil
@@ -95,7 +95,7 @@ jobs:
         gsutil -m cp dist/invest-workbench* \
           "${{ env.BUCKET }}/invest-workbench/${{ env.PKG_VERSION }}_${{ env.GIT_REV }}/"
 
-    - name: Deploy artifacts to GCS - not Windows
+    - name: Deploy artifacts to GCS - Not Windows
       # Secrets not available in PR so don't use GCP.
       if: github.event_name != 'pull_request' && matrix.os != 'windows-latest'
       run: |

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -20,7 +20,7 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    
+
     - name: NPM Install
       run: npm install
 


### PR DESCRIPTION
This PR adds an Actions step for deploying the electron-builder products (Windows exe installer & Mac DMG) to GCS buckets. Builds on natcap's fork deploy to our releases bucket with an `invest-workbench` prefix. Builds on other forks deploy to natcap-dev-build-artifacts bucket.

Note to self: "undraft" this PR after #72 & #73 are merged into `main`.