### PR TITLE
Task/80 update to invest 3.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,9 +58,9 @@
   },
   "invest": {
     "hostname": "https://storage.googleapis.com",
-    "bucket": "natcap-dev-build-artifacts",
-    "fork": "invest/davemfish",
-    "version": "3.8.9.post1130+gdd914a7a",
+    "bucket": "releases.naturalcapitalproject.org",
+    "fork": "natcap",
+    "version": "3.9.0.post147+gcc5a7cfe",
     "target": {
       "macos": "mac_invest_binaries.zip",
       "windows": "windows_invest_binaries.zip"

--- a/scripts/fetch_invest_binaries.js
+++ b/scripts/fetch_invest_binaries.js
@@ -22,13 +22,16 @@ switch (process.platform) {
 
 const HOSTNAME = pkg.invest.hostname;
 const BUCKET = pkg.invest.bucket;
-const FORK = pkg.invest.fork;
+// forknames are only in the path on the dev-builds bucket
+const FORK = BUCKET === 'releases.naturalcapitalproject.org'
+  ? '' : pkg.invest.fork;
+const REPO = 'invest';
 const VERSION = pkg.invest.version;
 const SRCFILE = `${filePrefix}_invest_binaries.zip`;
 const DESTFILE = path.resolve('build/binaries.zip');
 
 const urladdress = url.resolve(
-  HOSTNAME, path.join(BUCKET, FORK, VERSION, SRCFILE)
+  HOSTNAME, path.join(BUCKET, REPO, FORK, VERSION, SRCFILE)
 );
 
 /**


### PR DESCRIPTION
Fixes #80 

This PR updates the package.json to build against a post-3.9.0 version of invest. It also fixes a bug in the script that fetches prebuilt invest binaries from the releases bucket. This is the first time that functionality has been used in practice.