### PR TITLE
Bugfix/82 invest logging markup

### DIFF
--- a/src/components/LogTab/index.jsx
+++ b/src/components/LogTab/index.jsx
@@ -15,14 +15,15 @@ import Portal from '../Portal';
 import { getLogger } from '../../logger';
 
 const logger = getLogger(__filename.split('/').slice(-2).join('/'));
-const INVEST_LOG_PREFIX = '^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2},[0-9]{3}';
-// e.g. '2020-10-16 07:13:04,325 (natcap.invest.carbon) INFO ...'
 
 const LOG_TEXT_TAG = 'span';
 const ALLOWED_HTML_OPTIONS = {
   allowedTags: [LOG_TEXT_TAG],
   allowedAttributes: { [LOG_TEXT_TAG]: ['class'] },
 };
+const LOG_ERROR_REGEX = /(Traceback)|(([A-Z]{1}[a-z]*){1,}Error)|(ERROR)|(^\s\s*)/;
+const INVEST_LOG_PREFIX = '^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2},[0-9]{3}';
+// e.g. '2020-10-16 07:13:04,325 (natcap.invest.carbon) INFO ...'
 
 class LogDisplay extends React.Component {
   constructor(props) {
@@ -79,11 +80,9 @@ export default class LogTab extends React.Component {
       logdata: null,
     };
     this.tail = null;
-    const { pyModuleName } = this.props;
-    const primaryPattern = new RegExp(pyModuleName);
     this.logPatterns = {
-      'invest-log-error': /(Traceback)|(([A-Z]{1}[a-z]*){1,}Error)|(ERROR)|(^\s\s*)/,
-      'invest-log-primary': primaryPattern,
+      'invest-log-error': LOG_ERROR_REGEX,
+      'invest-log-primary': new RegExp(this.props.pyModuleName),
     };
 
     this.handleOpenWorkspace = this.handleOpenWorkspace.bind(this);
@@ -200,7 +199,7 @@ export default class LogTab extends React.Component {
         }
       } else {
         // Placeholder for a recent job re-loaded, logStdErr data doesn't persist.
-        lastCall = 'Error (see Log for details)';
+        lastCall = 'Model ended with error - see Log for details';
       }
 
       ModelStatusAlert = (

--- a/src/components/LogTab/index.jsx
+++ b/src/components/LogTab/index.jsx
@@ -82,7 +82,7 @@ export default class LogTab extends React.Component {
     const { pyModuleName } = this.props;
     const primaryPattern = new RegExp(pyModuleName);
     this.logPatterns = {
-      'invest-log-error': /(Traceback)|(^\s*[A-Z]{1}[a-z]*Error)|(ERROR)|(^\s\s*)/,
+      'invest-log-error': /(Traceback)|(([A-Z]{1}[a-z]*){1,}Error)|(ERROR)|(^\s\s*)/,
       'invest-log-primary': primaryPattern,
     };
 

--- a/src/components/LogTab/index.jsx
+++ b/src/components/LogTab/index.jsx
@@ -15,8 +15,8 @@ import Portal from '../Portal';
 import { getLogger } from '../../logger';
 
 const logger = getLogger(__filename.split('/').slice(-2).join('/'));
-const INVEST_LOG_PATTERN = '^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2},[0-9]{3}';
-// e.g. '2020-10-16 07:13:04,325 carbon.execute() ...'
+const INVEST_LOG_PREFIX = '^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2},[0-9]{3}';
+// e.g. '2020-10-16 07:13:04,325 (natcap.invest.carbon) INFO ...'
 
 const LOG_TEXT_TAG = 'span';
 const ALLOWED_HTML_OPTIONS = {

--- a/src/components/LogTab/index.jsx
+++ b/src/components/LogTab/index.jsx
@@ -80,10 +80,7 @@ export default class LogTab extends React.Component {
     };
     this.tail = null;
     const { pyModuleName } = this.props;
-    const primaryPyLogger = `${pyModuleName}`.split('.').slice(-1)[0];
-    const primaryPattern = new RegExp(
-      `${INVEST_LOG_PATTERN} ${primaryPyLogger}`
-    );
+    const primaryPattern = new RegExp(pyModuleName);
     this.logPatterns = {
       'invest-log-error': /(Traceback)|(^\s*[A-Z]{1}[a-z]*Error)|(ERROR)|(^\s\s*)/,
       'invest-log-primary': primaryPattern,

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -258,24 +258,25 @@ input[type=text]::placeholder {
 /* InVEST Log Tab */
 #log-display {
 	overflow: auto;
-  white-space: pre-wrap;
+	white-space: pre-wrap;
 	height: 85vh;
-  background-color: #191919;
+	/*background-color: #191919;*/
 }
 
 #log-text {
 	font-family: monospace;
 	font-size:1.3rem;
-	color: #e5e5e5;
+	color: #000;
 }
 
 #log-text .invest-log-primary {
-	color: #fff;
-	font-size: 1.2rem;
+	color: #000;
+	font-weight: bold;
 }
 
 #log-text .invest-log-error {
-	color: #ffc13e;
+	color: #f13232;
+	font-weight: bold;
 }
 
 .invest-sidebar-col .alert {

--- a/tests/logtab.test.js
+++ b/tests/logtab.test.js
@@ -2,12 +2,27 @@ import path from 'path';
 import fs from 'fs';
 import React from 'react';
 import {
-  fireEvent, render, waitFor, within
+  render, waitFor, within
 } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 import LogTab from '../src/components/LogTab';
 import { cleanupDir } from '../src/utils';
+
+function renderLogTab(logfilePath, primaryPythonLogger) {
+  const { ...utils } = render(
+    <LogTab
+      jobStatus="success"
+      logfile={logfilePath}
+      logStdErr=""
+      procID={undefined}
+      pyModuleName={primaryPythonLogger}
+      terminateInvestProcess={() => {}}
+      sidebarFooterElementId="divID"
+    />
+  );
+  return utils;
+}
 
 describe('LogTab', () => {
   let workspace;
@@ -39,16 +54,8 @@ workspace_dir                 C:/Users/dmf/projects/invest-workbench/runs/awy
   });
 
   test('Text in logfile is rendered', async () => {
-    const { findByText } = render(
-      <LogTab
-        jobStatus="success"
-        logfile={logfilePath}
-        logStdErr=""
-        procID={undefined}
-        pyModuleName={primaryPythonLogger}
-        terminateInvestProcess={() => {}}
-        sidebarFooterElementId="divID"
-      />
+    const { findByText } = renderLogTab(
+      logfilePath, primaryPythonLogger
     );
 
     const log = await findByText(new RegExp(uniqueText));
@@ -56,16 +63,8 @@ workspace_dir                 C:/Users/dmf/projects/invest-workbench/runs/awy
   });
 
   test('message from non-primary invest logger is plain', async () => {
-    const { findByText } = render(
-      <LogTab
-        jobStatus="success"
-        logfile={logfilePath}
-        logStdErr=""
-        procID={undefined}
-        pyModuleName={primaryPythonLogger}
-        terminateInvestProcess={() => {}}
-        sidebarFooterElementId="divID"
-      />
+    const { findByText } = renderLogTab(
+      logfilePath, primaryPythonLogger
     );
 
     const log = await findByText(new RegExp(uniqueText));
@@ -73,16 +72,8 @@ workspace_dir                 C:/Users/dmf/projects/invest-workbench/runs/awy
   });
 
   test('messages from primary invest logger are highlighted', async () => {
-    const { findAllByText } = render(
-      <LogTab
-        jobStatus="success"
-        logfile={logfilePath}
-        logStdErr=""
-        procID={undefined}
-        pyModuleName={primaryPythonLogger}
-        terminateInvestProcess={() => {}}
-        sidebarFooterElementId="divID"
-      />
+    const { findAllByText } = renderLogTab(
+      logfilePath, primaryPythonLogger
     );
 
     const messages = await findAllByText(new RegExp(primaryPythonLogger));

--- a/tests/logtab.test.js
+++ b/tests/logtab.test.js
@@ -30,6 +30,7 @@ describe('LogTab', () => {
   const logfileName = 'logfile.txt';
   const uniqueText = 'utils.prepare_workspace';
   const primaryPythonLogger = 'natcap.invest.hydropower.hydropower_water_yield';
+
   const logText = `
 2021-01-15 07:14:37,147 (natcap.invest.utils) ${uniqueText}(124) INFO Writing log ...
 2021-01-15 07:14:37,147 (__main__) cli.main(521) Level 100 Starting model with parameters: 
@@ -41,6 +42,24 @@ workspace_dir                 C:/Users/dmf/projects/invest-workbench/runs/awy
 2021-01-15 07:14:37,148 (natcap.invest.validation) validation._wrapped_validate_func(915) INFO ...
 2021-01-15 07:14:37,525 (taskgraph.Task) Task.__init__(333) WARNING the ...
 2021-01-15 07:14:37,636 (pygeoprocessing.geoprocessing) geoprocessing.align_and_resize_raster_stack(795) INFO ...
+
+2021-01-19 14:08:32,779 (taskgraph.Task) Task.add_task(781) ERROR Something went wrong when adding task ...
+Traceback (most recent call last):
+  File site-packages/natcap/invest/utils.py, line 860, in reclassify_raster
+  File site-packages/pygeoprocessing/geoprocessing.py, line 1836, in reclassify_raster
+  File site-packages/pygeoprocessing/geoprocessing.py, line 438, in raster_calculator
+  File site-packages/pygeoprocessing/geoprocessing.py, line 1829, in _map_dataset_to_value_op
+pygeoprocessing.geoprocessing.ReclassificationMissingValuesError: (The following 1 raster values [8] from ...
+
+During handling of the above exception, another exception occurred:
+
+Traceback (most recent call last):
+  File site-packages/taskgraph/Task.py, line 747, in add_task
+  File site-packages/taskgraph/Task.py, line 1234, in _call
+  File site-packages/natcap/invest/sdr/sdr.py, line 997, in _calculate_w
+  File site-packages/natcap/invest/utils.py, line 868, in reclassify_raster
+ValueError: Values in the LULC raster were found that are not represented under the lucode column of the Biophysical table....
+2021-01-19 14:08:32,780 (natcap.invest.utils) utils.prepare_workspace(130) INFO Elapsed time: 3.5s
 `;
 
   beforeEach(() => {
@@ -79,6 +98,42 @@ workspace_dir                 C:/Users/dmf/projects/invest-workbench/runs/awy
     const messages = await findAllByText(new RegExp(primaryPythonLogger));
     messages.forEach((msg) => {
       expect(msg).toHaveClass('invest-log-primary');
+    });
+  });
+
+  test('error messages are highlighted', async () => {
+    const { findAllByText } = renderLogTab(
+      logfilePath, primaryPythonLogger
+    );
+
+    // The start of a python traceback
+    let errorMessages = await findAllByText(/Traceback/);
+    errorMessages.forEach((msg) => {
+      expect(msg).toHaveClass('invest-log-error');
+    });
+
+    // The indented contents of a python traceback
+    errorMessages = await findAllByText(/File site-packages/);
+    errorMessages.forEach((msg) => {
+      expect(msg).toHaveClass('invest-log-error');
+    });
+
+    // an ERROR-level message from a python logger
+    errorMessages = await findAllByText(/ERROR Something went wrong/);
+    errorMessages.forEach((msg) => {
+      expect(msg).toHaveClass('invest-log-error');
+    });
+
+    // a message from a custom python exception class
+    errorMessages = await findAllByText(/ReclassificationMissingValuesError/);
+    errorMessages.forEach((msg) => {
+      expect(msg).toHaveClass('invest-log-error');
+    });
+
+    // a message from a built-in python exception class
+    errorMessages = await findAllByText(/ValueError:/);
+    errorMessages.forEach((msg) => {
+      expect(msg).toHaveClass('invest-log-error');
     });
   });
 });

--- a/tests/logtab.test.js
+++ b/tests/logtab.test.js
@@ -1,3 +1,7 @@
+/* These tests cover how an existing logfile is rendered. Other tests in
+app.test.js cover the integrations between the log components and others,
+like how starting and stopping invest subprocesses trigger log updates.
+*/
 import path from 'path';
 import fs from 'fs';
 import React from 'react';

--- a/tests/logtab.test.js
+++ b/tests/logtab.test.js
@@ -1,0 +1,93 @@
+import path from 'path';
+import fs from 'fs';
+import React from 'react';
+import {
+  fireEvent, render, waitFor, within
+} from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import LogTab from '../src/components/LogTab';
+import { cleanupDir } from '../src/utils';
+
+describe('LogTab', () => {
+  let workspace;
+  let logfilePath;
+  const logfileName = 'logfile.txt';
+  const uniqueText = 'utils.prepare_workspace';
+  const primaryPythonLogger = 'natcap.invest.hydropower.hydropower_water_yield';
+  const logText = `
+2021-01-15 07:14:37,147 (natcap.invest.utils) ${uniqueText}(124) INFO Writing log ...
+2021-01-15 07:14:37,147 (__main__) cli.main(521) Level 100 Starting model with parameters: 
+Arguments for InVEST ${primaryPythonLogger} 3.9.0.post147+gcc5a7cfe:
+biophysical_table_path        C:/Users/dmf/projects/invest/data/biophysical_table_gura.csv
+workspace_dir                 C:/Users/dmf/projects/invest-workbench/runs/awy
+
+2021-01-15 07:14:37,148 (${primaryPythonLogger}) hydropower_water_yield.execute(268) INFO Validating arguments
+2021-01-15 07:14:37,148 (natcap.invest.validation) validation._wrapped_validate_func(915) INFO ...
+2021-01-15 07:14:37,525 (taskgraph.Task) Task.__init__(333) WARNING the ...
+2021-01-15 07:14:37,636 (pygeoprocessing.geoprocessing) geoprocessing.align_and_resize_raster_stack(795) INFO ...
+`;
+
+  beforeEach(() => {
+    workspace = fs.mkdtempSync(path.join('tests/data', 'log-'));
+    logfilePath = path.join(workspace, logfileName);
+    fs.writeFileSync(logfilePath, logText);
+  });
+
+  afterEach(() => {
+    cleanupDir(workspace);
+  });
+
+  test('Text in logfile is rendered', async () => {
+    const { findByText } = render(
+      <LogTab
+        jobStatus="success"
+        logfile={logfilePath}
+        logStdErr=""
+        procID={undefined}
+        pyModuleName={primaryPythonLogger}
+        terminateInvestProcess={() => {}}
+        sidebarFooterElementId="divID"
+      />
+    );
+
+    const log = await findByText(new RegExp(uniqueText));
+    expect(log).toBeInTheDocument();
+  });
+
+  test('message from non-primary invest logger is plain', async () => {
+    const { findByText } = render(
+      <LogTab
+        jobStatus="success"
+        logfile={logfilePath}
+        logStdErr=""
+        procID={undefined}
+        pyModuleName={primaryPythonLogger}
+        terminateInvestProcess={() => {}}
+        sidebarFooterElementId="divID"
+      />
+    );
+
+    const log = await findByText(new RegExp(uniqueText));
+    expect(log).not.toHaveClass();
+  });
+
+  test('messages from primary invest logger are highlighted', async () => {
+    const { findAllByText } = render(
+      <LogTab
+        jobStatus="success"
+        logfile={logfilePath}
+        logStdErr=""
+        procID={undefined}
+        pyModuleName={primaryPythonLogger}
+        terminateInvestProcess={() => {}}
+        sidebarFooterElementId="divID"
+      />
+    );
+
+    const messages = await findAllByText(new RegExp(primaryPythonLogger));
+    messages.forEach((msg) => {
+      expect(msg).toHaveClass('invest-log-primary');
+    });
+  });
+});


### PR DESCRIPTION
Fixes #82 

This PR adds test coverage for the log component's rendering and markup of invest logs. It's compatible with invest 3.9.0 logs, where we slightly altered the format of the log messages.