### PR TITLE
Bugfix/86 log messages display delayed

### DIFF
--- a/src/components/LogTab/index.jsx
+++ b/src/components/LogTab/index.jsx
@@ -119,6 +119,7 @@ export default class LogTab extends React.Component {
     try {
       this.tail = new Tail(logfile, {
         fromBeginning: true,
+        logger: logger,
       });
       let markup = Object.assign('', this.state.logdata);
       this.tail.on('line', (data) => {

--- a/src/main_helpers.js
+++ b/src/main_helpers.js
@@ -60,8 +60,11 @@ export function createPythonFlaskProcess(investExe) {
     const pythonServerProcess = spawn(
       path.basename(investExe),
       ['serve', '--port', process.env.PORT],
-      { env: { PATH: path.dirname(investExe) } }
-    );
+      { env: {
+          PATH: path.dirname(investExe),
+          QT_MAC_WANTS_LAYER: 1
+      }
+    });
 
     logger.debug(`Started python process as PID ${pythonServerProcess.pid}`);
     logger.debug(investExe);

--- a/src/main_helpers.js
+++ b/src/main_helpers.js
@@ -60,11 +60,12 @@ export function createPythonFlaskProcess(investExe) {
     const pythonServerProcess = spawn(
       path.basename(investExe),
       ['serve', '--port', process.env.PORT],
-      { env: {
+      {
+        env: {
           PATH: path.dirname(investExe),
-          QT_MAC_WANTS_LAYER: 1
+        },
       }
-    });
+    );
 
     logger.debug(`Started python process as PID ${pythonServerProcess.pid}`);
     logger.debug(investExe);


### PR DESCRIPTION
This PR fixes #86 by forcing `node-tail` to use `fs.watchFile` instead of `fs.watch` (the default).  It turns out that on Windows, the mechanism that `fs.watch` uses will only notify node when the watched file _closes_, which is a problem on long-running models as the logfile won't close until model completion.  The alternative, `fs.watchFile` will poll the watched file's modified time on an interval and then report back to node if it's changed.

The node docs suggest that `fs.watch` is more efficient, but it doesn't serve our needs in this case.  The proposed changes will only use `fs.watchFile` on Windows and on all other OSes use `fs.watch`, which is more efficient.

A few experiments exist in https://github.com/phargogh/experiment-windows-node-fs-watch if you'd like to try these out in person.