### PR TITLE
switched mac build target from zip to dmg

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "mac": {
       "category": "public.app-category.business",
       "icon": "build/icon.png",
-      "target": "zip"
+      "target": "dmg"
     },
     "linux": {
       "target": [


### PR DESCRIPTION
Fixes #94 

We had problems with the zip, and the dmg just works.