### PR TITLE
launch the flask subprocess with a logging level arg

### DIFF
--- a/src/main_helpers.js
+++ b/src/main_helpers.js
@@ -60,7 +60,7 @@ export function createPythonFlaskProcess(investExe) {
   if (investExe) {
     const pythonServerProcess = spawn(
       path.basename(investExe),
-      ['serve', '--port', process.env.PORT],
+      ['--debug', 'serve', '--port', process.env.PORT],
       {
         env: {
           PATH: path.dirname(investExe),


### PR DESCRIPTION
Fixes #99 

The invest CLI defaults to `CRITICAL`, but we have a bunch of useful `DEBUG` level messages in `ui_server.py` (and further python modules) that should make it to stdout.