### PR TITLE
Add version & git revision identifiers to artifact filenames

### DIFF
--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -19,6 +19,11 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
+      with:
+        fetch-depth: 0  # fetch complete history
+
+    - name: Fetch git tags
+      run: git fetch origin +refs/tags/*:refs/tags/*
 
     - name: Install Node.js
       uses: actions/setup-node@v1

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -47,12 +47,12 @@ jobs:
     - name: Test electron app with puppeteer
       uses: GabrielBB/xvfb-action@v1
       if: matrix.os != 'macos-latest'
+      continue-on-error: true
       with:
         run: npm run test-electron-app
     
     - name: Upload installer artifacts to github
       uses: actions/upload-artifact@v2.2.1
-      if: ${{ always() }}
       with:
         name: invest-workbench-${{ matrix.os }}
         path: dist/invest-workbench_*

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -67,7 +67,7 @@ jobs:
     - name: Set variables for GCS deploy target
       if: github.event_name != 'pull_request'
       run: |
-        echo "VERSION"=$(git describe --tags) >> $GITHUB_ENV
+        echo "VERSION"=$(grep VERSION electron-builder.env | cut -d '=' -f2) >> $GITHUB_ENV
         echo "BUCKET=$([ ${{ github.repository_owner }} == 'natcap' ] \
           && echo 'gs://releases.naturalcapitalproject.org/invest-workbench' \
           || echo 'gs://natcap-dev-build-artifacts/invest-workbench/${{ github.repository_owner }}' \

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -61,10 +61,8 @@ jobs:
     # to authenticate for GCP and they are not accessible in pull request workflows.
     - name: Set variables for GCS deploy target
       if: github.event_name != 'pull_request'
-      # TODO: If this is a release, don't include the commit hash
       run: |
-        echo "PKG_VERSION=$(jq -r .version package.json)" >> $GITHUB_ENV
-        echo "GIT_REV=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+        echo "VERSION"=$(git describe --tags) >> $GITHUB_ENV
         echo "BUCKET=$([ ${{ github.repository_owner }} == 'natcap' ] \
           && echo 'gs://releases.naturalcapitalproject.org/invest-workbench' \
           || echo 'gs://natcap-dev-build-artifacts/invest-workbench/${{ github.repository_owner }}' \
@@ -88,9 +86,9 @@ jobs:
       env:
         CLOUDSDK_PYTHON: ${{env.pythonLocation}}\python.exe
       run: |
-        gsutil -m rsync dist/ "${{ env.BUCKET }}/${{ env.PKG_VERSION }}_${{ env.GIT_REV }}/"
+        gsutil -m rsync dist/ "${{ env.BUCKET }}/${{ env.VERSION }}/"
 
     - name: Deploy artifacts to GCS - macOS
       if: github.event_name != 'pull_request' && matrix.os == 'macos-latest'
       run: |
-        gsutil -m rsync dist/ "${{ env.BUCKET }}/${{ env.PKG_VERSION }}_${{ env.GIT_REV }}/"
+        gsutil -m rsync dist/ "${{ env.BUCKET }}/${{ env.VERSION }}/"

--- a/build.js
+++ b/build.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { spawnSync } = require('child_process');
+const { execFileSync, spawnSync } = require('child_process');
 const fs = require('fs-extra');
 const path = require('path');
 const glob = require('glob');
@@ -13,6 +13,7 @@ if (process.argv[2] && process.argv[2] === 'clean') {
 } else {
   clean();
   build();
+  getGitRev();
 }
 
 /** Remove all the files created during build()
@@ -66,4 +67,14 @@ function build() {
       fs.copySync(file, dest);
     }
   });
+}
+
+/** Uniquely identify the changeset we're building & packaging.
+ *
+ * electron-builder will read this .env file and use the string in
+ * the artifactName.
+ */
+function getGitRev() {
+  const rev = execFileSync('git', ['rev-parse', '--short', 'HEAD']);
+  fs.writeFileSync('electron-builder.env', `GITREV=${rev}`);
 }

--- a/build.js
+++ b/build.js
@@ -40,7 +40,9 @@ function clean() {
       fs.unlinkSync(file);
     }
   });
-  fs.unlinkSync(ELECTRON_BUILDER_ENV);
+  try {
+    fs.unlinkSync(ELECTRON_BUILDER_ENV);
+  } catch {}
 }
 
 /** Transpile and copy all src/ code to build folder. */

--- a/build.js
+++ b/build.js
@@ -14,7 +14,7 @@ if (process.argv[2] && process.argv[2] === 'clean') {
 } else {
   clean();
   build();
-  getGitRev();
+  makeVersionString();
 }
 
 /** Remove all the files created during build()
@@ -78,8 +78,8 @@ function build() {
  * electron-builder will read this .env file and use the string in
  * the artifactName.
  */
-function getGitRev() {
-  const rev = execFileSync('git', ['describe', '--tags']);
-  fs.writeFileSync(ELECTRON_BUILDER_ENV, `GITREV=${rev}`);
-  console.log(`built version ${rev}`);
+function makeVersionString() {
+  const version = execFileSync('git', ['describe', '--tags']);
+  fs.writeFileSync(ELECTRON_BUILDER_ENV, `VERSION=${version}`);
+  console.log(`built version ${version}`);
 }

--- a/build.js
+++ b/build.js
@@ -7,6 +7,7 @@ const glob = require('glob');
 
 const SRC_DIR = 'src';
 const BUILD_DIR = 'build';
+const ELECTRON_BUILDER_ENV = 'electron-builder.env';
 
 if (process.argv[2] && process.argv[2] === 'clean') {
   clean();
@@ -39,6 +40,7 @@ function clean() {
       fs.unlinkSync(file);
     }
   });
+  fs.unlinkSync(ELECTRON_BUILDER_ENV);
 }
 
 /** Transpile and copy all src/ code to build folder. */
@@ -75,6 +77,7 @@ function build() {
  * the artifactName.
  */
 function getGitRev() {
-  const rev = execFileSync('git', ['rev-parse', '--short', 'HEAD']);
-  fs.writeFileSync('electron-builder.env', `GITREV=${rev}`);
+  const rev = execFileSync('git', ['describe', '--tags']);
+  fs.writeFileSync(ELECTRON_BUILDER_ENV, `GITREV=${rev}`);
+  console.log(`built version ${rev}`);
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     ],
     "appId": "NaturalCapitalProject.Invest.Workbench",
     "productName": "InVEST Workbench",
-    "artifactName": "invest-workbench_${os}_${arch}_${version}.${ext}",
+    "artifactName": "invest-workbench_${os}_${arch}_${version}_${env.GITREV}.${ext}",
     "mac": {
       "category": "public.app-category.business",
       "icon": "resources/invest-in-shadow-white.png",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     ],
     "appId": "NaturalCapitalProject.Invest.Workbench",
     "productName": "InVEST Workbench",
-    "artifactName": "invest-workbench_${os}_${arch}_${env.GITREV}.${ext}",
+    "artifactName": "invest-workbench_${os}_${arch}_${env.VERSION}.${ext}",
     "mac": {
       "category": "public.app-category.business",
       "icon": "resources/invest-in-shadow-white.png",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     ],
     "appId": "NaturalCapitalProject.Invest.Workbench",
     "productName": "InVEST Workbench",
-    "artifactName": "invest-workbench_${os}_${arch}_${version}_${env.GITREV}.${ext}",
+    "artifactName": "invest-workbench_${os}_${arch}_${env.GITREV}.${ext}",
     "mac": {
       "category": "public.app-category.business",
       "icon": "resources/invest-in-shadow-white.png",


### PR DESCRIPTION
This fixes #117 

Now that we have our first tag ( `0.1.0-alpha`) we can use `git describe --tags` to get a string that brings more meaning to our artifact filenames. This is especially helpful for dev builds, where we can see how many commits after the tagged commit a build is at (6) as well as the changeset that was built:

> invest-workbench_win_0.1.0-alpha-6-g5e478f0.exe

And conveniently, `git describe --tags` when HEAD is a tag, makes a string without the revision hash. So that's nice for a release build:

> invest-workbench_win_0.1.0-alpha.exe