### PR TITLE
Bugfix/96 unreliable windows puppeteer

### DIFF
--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -57,8 +57,8 @@ jobs:
       uses: actions/upload-artifact@v2.2.1
       if: matrix.os != 'macos-latest' && always()
       with:
-        name: 'puppeteer_log.txt'
-        path: '~/AppData/Roaming/invest-workbench/invest-workbench-log*'
+        name: 'puppeteer_log.zip'
+        path: '~/AppData/Roaming/invest-workbench/invest-workbench*'
 
     - name: Upload installer artifacts to github
       uses: actions/upload-artifact@v2.2.1

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -58,7 +58,7 @@ jobs:
       if: matrix.os != 'macos-latest'
       with:
         name: 'puppeteer_log.txt'
-        path: '~/AppData/Roaming/invest-workbench-log*'
+        path: '~/AppData/Roaming/invest-workbench/invest-workbench-log*'
 
     - name: Upload installer artifacts to github
       uses: actions/upload-artifact@v2.2.1

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -53,6 +53,13 @@ jobs:
       if: matrix.os != 'macos-latest'
       run: npm run test-electron-app
 
+    - name: Upload app logging from puppeteer to github
+      uses: actions/upload-artifact@v2.2.1
+      if: matrix.os != 'macos-latest'
+      with:
+        name: 'puppeteer_log.txt'
+        path: '~/AppData/Roaming/invest-workbench-log*'
+
     - name: Upload installer artifacts to github
       uses: actions/upload-artifact@v2.2.1
       if: ${{ always() }}

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -55,7 +55,7 @@ jobs:
 
     - name: Upload app logging from puppeteer to github
       uses: actions/upload-artifact@v2.2.1
-      if: matrix.os != 'macos-latest'
+      if: matrix.os != 'macos-latest' && always()
       with:
         name: 'puppeteer_log.txt'
         path: '~/AppData/Roaming/invest-workbench/invest-workbench-log*'

--- a/src/components/InvestTab/index.jsx
+++ b/src/components/InvestTab/index.jsx
@@ -127,6 +127,7 @@ export default class InvestTab extends React.Component {
    *   as a javascript object
    */
   async investExecute(argsValues) {
+    logger.debug('from investExecute');
     const {
       job,
       investExe,
@@ -154,6 +155,7 @@ export default class InvestTab extends React.Component {
       fileRegistry.TEMP_DIR, 'data-'
     ));
     const datastackPath = path.join(tempDir, 'datastack.json');
+    logger.debug('before writing parameters to file');
     await this.argsToJsonFile(datastackPath, args);
 
     const cmdArgs = [

--- a/src/components/InvestTab/index.jsx
+++ b/src/components/InvestTab/index.jsx
@@ -127,7 +127,6 @@ export default class InvestTab extends React.Component {
    *   as a javascript object
    */
   async investExecute(argsValues) {
-    logger.debug('from investExecute');
     const {
       job,
       investExe,
@@ -155,7 +154,6 @@ export default class InvestTab extends React.Component {
       fileRegistry.TEMP_DIR, 'data-'
     ));
     const datastackPath = path.join(tempDir, 'datastack.json');
-    logger.debug('before writing parameters to file');
     await this.argsToJsonFile(datastackPath, args);
 
     const cmdArgs = [

--- a/src/components/SetupTab/index.jsx
+++ b/src/components/SetupTab/index.jsx
@@ -192,6 +192,7 @@ export default class SetupTab extends React.Component {
   }
 
   wrapInvestExecute() {
+    logger.debug('from run button click handler');
     const argsValues = this.insertNWorkers(this.state.argsValues);
     this.props.investExecute(argsDictFromObject(argsValues));
   }

--- a/src/components/SetupTab/index.jsx
+++ b/src/components/SetupTab/index.jsx
@@ -12,8 +12,8 @@ import {
 } from './SetupButtons';
 import { fetchValidation, saveToPython } from '../../server_requests';
 import { argsDictFromObject } from '../../utils';
-
-
+import { getLogger } from '../../logger';
+const logger = getLogger(__filename.split('/').slice(-1)[0]);
 /** Setup the objects that store InVEST argument values in SetupTab state.
  *
  * One object will store input form values and track if the input has been
@@ -311,6 +311,8 @@ export default class SetupTab extends React.Component {
         isRunning,
         uiSpec
       } = this.props;
+      logger.debug(`ARGS VALID: ${argsValid}`);
+      logger.debug(`IS RUNNING: ${isRunning}`);
 
       const buttonText = (
         isRunning

--- a/src/components/SetupTab/index.jsx
+++ b/src/components/SetupTab/index.jsx
@@ -12,8 +12,7 @@ import {
 } from './SetupButtons';
 import { fetchValidation, saveToPython } from '../../server_requests';
 import { argsDictFromObject } from '../../utils';
-import { getLogger } from '../../logger';
-const logger = getLogger(__filename.split('/').slice(-1)[0]);
+
 /** Setup the objects that store InVEST argument values in SetupTab state.
  *
  * One object will store input form values and track if the input has been
@@ -192,7 +191,6 @@ export default class SetupTab extends React.Component {
   }
 
   wrapInvestExecute() {
-    logger.debug('from run button click handler');
     const argsValues = this.insertNWorkers(this.state.argsValues);
     this.props.investExecute(argsDictFromObject(argsValues));
   }
@@ -312,8 +310,6 @@ export default class SetupTab extends React.Component {
         isRunning,
         uiSpec
       } = this.props;
-      logger.debug(`ARGS VALID: ${argsValid}`);
-      logger.debug(`IS RUNNING: ${isRunning}`);
 
       const buttonText = (
         isRunning

--- a/tests/binary_tests/puppet.test.js
+++ b/tests/binary_tests/puppet.test.js
@@ -151,7 +151,7 @@ test('Run a real invest model', async () => {
     const prop = await logTab.getProperty('className');
     const vals = await prop.jsonValue();
     expect(vals.includes('active')).toBeTruthy();
-  }, 18000); // 4x default timeout: sometimes this expires unmet in GHA
+  }, 72000); // 16x default timeout: sometimes this expires unmet in GHA
 
   const cancelButton = await findByText(doc, 'Cancel Run');
   cancelButton.click();

--- a/tests/binary_tests/puppet.test.js
+++ b/tests/binary_tests/puppet.test.js
@@ -30,13 +30,10 @@ if (process.platform === 'darwin') {
 } else {
   BINARY_PATH = './dist/linux-unpacked/invest-workbench';
 }
-
 if (!fs.existsSync(BINARY_PATH)) {
   throw new Error(`Binary file not found: ${BINARY_PATH}`);
 }
-if (!fs.accessSync(BINARY_PATH, fs.constants.X_OK)) {
-  throw new Error(`Binary file not executeable: ${BINARY_PATH}`);
-}
+fs.accessSync(BINARY_PATH, fs.constants.X_OK);
 
 function makeAOI() {
   /* eslint-disable */

--- a/tests/binary_tests/puppet.test.js
+++ b/tests/binary_tests/puppet.test.js
@@ -111,14 +111,11 @@ test('Run a real invest model', async () => {
   await waitFor(() => {
     expect(browser.isConnected()).toBeTruthy();
   });
-  const pages = (await browser.pages());
   // find the mainWindow's index.html, not the splashScreen's splash.html
-  let page;
-  pages.forEach((p) => {
-    if (p.url().endsWith('index.html')) {
-      page = p;
-    }
-  });
+  const target = await browser.waitForTarget(
+    target => target.url().endsWith('index.html')
+  );
+  const page = await target.page()
   const doc = await getDocument(page);
 
   // Setting up Recreation model because it has very few data requirements

--- a/tests/binary_tests/puppet.test.js
+++ b/tests/binary_tests/puppet.test.js
@@ -122,6 +122,12 @@ test('Run a real invest model', async () => {
   const investTable = await findByRole(doc, 'table');
   const button = await findByRole(investTable, 'button', { name: /Visitation/ });
   button.click();
+  const runButton = await findByRole(doc, 'button', { name: 'Run' });
+  const preEnabled = await page.evaluate(
+    (btn) => !btn.disabled,
+    runButton
+  );
+  console.log(`run button is enabled: ${preEnabled}`);
   const workspace = await findByLabelText(doc, /Workspace/);
   await workspace.type(TMP_DIR, { delay: 10 });
   const aoi = await findByLabelText(doc, /Area of Interest/);
@@ -131,18 +137,17 @@ test('Run a real invest model', async () => {
   const endYear = await findByLabelText(doc, /End Year/);
   await endYear.type('2012', { delay: 10 });
 
-  const runButton = await findByText(doc, 'Run');
 
   // Button is disabled until validation completes
+  let isEnabled;
   await waitFor(async () => {
-    console.log(`RUN IS DISABLED: ${runButton.disabled}`);
-    const isEnabled = await page.evaluate(
+    isEnabled = await page.evaluate(
       (btn) => !btn.disabled,
       runButton
     );
     expect(isEnabled).toBe(true);
   });
-
+  console.log(`RUN IS ENABLED: ${isEnabled}`);
   await runButton.click();
   const logTab = await findByText(doc, 'Log');
   // Log tab is not active until after the invest logfile is opened

--- a/tests/binary_tests/puppet.test.js
+++ b/tests/binary_tests/puppet.test.js
@@ -132,13 +132,15 @@ test('Run a real invest model', async () => {
   await endYear.type('2012', { delay: 10 });
 
   const runButton = await findByText(doc, 'Run');
+  
   // Button is disabled until validation completes
   await waitFor(async () => {
+    console.log(`RUN IS DISABLED: ${runButton.disabled}`);
     const isEnabled = await page.evaluate(
       (btn) => !btn.disabled,
       runButton
     );
-    expect(isEnabled).toBeTruthy();
+    expect(isEnabled).toBe(true);
   });
 
   runButton.click();
@@ -147,7 +149,7 @@ test('Run a real invest model', async () => {
   await waitFor(async () => {
     const prop = await logTab.getProperty('className');
     const vals = await prop.jsonValue();
-    console.log(`VALS ${JSON.stringify(vals)}`);
+    // console.log(`VALS ${JSON.stringify(vals)}`);
     expect(vals.includes('active')).toBeTruthy();
   });
 

--- a/tests/binary_tests/puppet.test.js
+++ b/tests/binary_tests/puppet.test.js
@@ -113,9 +113,9 @@ test('Run a real invest model', async () => {
   });
   // find the mainWindow's index.html, not the splashScreen's splash.html
   const target = await browser.waitForTarget(
-    target => target.url().endsWith('index.html')
+    (target) => target.url().endsWith('index.html')
   );
-  const page = await target.page()
+  const page = await target.page();
   const doc = await getDocument(page);
 
   // Setting up Recreation model because it has very few data requirements
@@ -147,8 +147,9 @@ test('Run a real invest model', async () => {
   await waitFor(async () => {
     const prop = await logTab.getProperty('className');
     const vals = await prop.jsonValue();
+    console.log(`VALS ${JSON.stringify(vals)}`);
     expect(vals.includes('active')).toBeTruthy();
-  }, 72000); // 16x default timeout: sometimes this expires unmet in GHA
+  });
 
   const cancelButton = await findByText(doc, 'Cancel Run');
   cancelButton.click();
@@ -156,7 +157,7 @@ test('Run a real invest model', async () => {
     expect(await findByText(doc, 'Run Canceled'));
     expect(await findByText(doc, 'Open Workspace'));
   });
-});
+}, 50000); // 10x default timeout: sometimes expires in GHA
 
 // Test for duplicate application launch.
 // We have the binary path, so now let's launch a new subprocess with the same binary

--- a/tests/binary_tests/puppet.test.js
+++ b/tests/binary_tests/puppet.test.js
@@ -132,7 +132,7 @@ test('Run a real invest model', async () => {
   await endYear.type('2012', { delay: 10 });
 
   const runButton = await findByText(doc, 'Run');
-  
+
   // Button is disabled until validation completes
   await waitFor(async () => {
     console.log(`RUN IS DISABLED: ${runButton.disabled}`);
@@ -143,7 +143,7 @@ test('Run a real invest model', async () => {
     expect(isEnabled).toBe(true);
   });
 
-  runButton.click();
+  await runButton.click();
   const logTab = await findByText(doc, 'Log');
   // Log tab is not active until after the invest logfile is opened
   await waitFor(async () => {
@@ -154,7 +154,7 @@ test('Run a real invest model', async () => {
   });
 
   const cancelButton = await findByText(doc, 'Cancel Run');
-  cancelButton.click();
+  await cancelButton.click();
   await waitFor(async () => {
     expect(await findByText(doc, 'Run Canceled'));
     expect(await findByText(doc, 'Open Workspace'));

--- a/tests/binary_tests/puppet.test.js
+++ b/tests/binary_tests/puppet.test.js
@@ -147,8 +147,8 @@ test('Run a real invest model', async () => {
   const cancelButton = await findByText(doc, 'Cancel Run');
   await cancelButton.click();
   await waitFor(async () => {
-    expect(await findByText(doc, 'Run Canceled')).toBeInTheDocument();
-    expect(await findByText(doc, 'Open Workspace')).toBeInTheDocument();
+    expect(await findByText(doc, 'Run Canceled'));
+    expect(await findByText(doc, 'Open Workspace'));
   });
 }, 50000); // 10x default timeout: sometimes expires in GHA
 

--- a/tests/binary_tests/puppet.test.js
+++ b/tests/binary_tests/puppet.test.js
@@ -155,7 +155,6 @@ test('Run a real invest model', async () => {
   await waitFor(async () => {
     const prop = await logTab.getProperty('className');
     const vals = await prop.jsonValue();
-    // console.log(`VALS ${JSON.stringify(vals)}`);
     expect(vals.includes('active')).toBeTruthy();
   });
 


### PR DESCRIPTION
This PR fixes #96. There were two sources of unreliability in the puppeteer tests that are fixed here:

1. `BROWSER.waitForTarget` avoids a race condition and an occasional undefined `page` that yielded errors like `cannot find property mainFrame of undefined` (or something like that).
2. connecting with `defaultViewport: null` avoids some unpredictable resizing that seemed to happen because of "viewport emulation" just before the run button `click`. That sometimes caused the mouse to miss the button and the test to hang until the `logTab` expect timed out. This solution was mentioned here: https://github.com/puppeteer/puppeteer/issues/1183

This PR also adds a screenshot to the test, which helped with debugging, and it uploads that image and the app's logfile to a github artifact, which was very helpful for debugging behavior that wouldn't reproduce locally. I left that stuff in because it could prove useful again and doesn't add too much of burden, I don't think.

And there's also some general cleanup of the test script.