### PR TITLE
cleanup the stream handlers in a WillUnmount. #138.

### DIFF
--- a/src/components/InvestTab/index.jsx
+++ b/src/components/InvestTab/index.jsx
@@ -96,6 +96,11 @@ export default class InvestTab extends React.Component {
     }, () => { this.switchTabs('setup'); });
   }
 
+  componentWillUnmout() {
+    // this object holds stream handlers, so it's important to clean up
+    this.investRun = null;
+  }
+
   /** Write an invest args JSON file for passing to invest cli.
    *
    * Outsourcing this to natcap.invest.datastack via flask ensures


### PR DESCRIPTION
Fixes #138 

Here's a tiny PR that hopefully address why some of our tests fail intermittently (mainly on macos Actions, I think). It's a little hard to know for certain that this solved the problem, but these tests have run & re-run a few times now with this change, and they have passed.

This affects the `npm run tests` tests, but not the puppeteer tests that run in the Build step. They have their own unrelated reliability issues.

Here's an example of formerly failing tests:
https://github.com/davemfish/invest-workbench/runs/2306056762?check_suite_focus=true