### PR TITLE
Bugfix/155 set state on unmounted component

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -31,11 +31,6 @@
         },
     },
     "rules": {
-        "object-shorthand": ["error", "never"],
-        "max-classes-per-file": ["error", 2],
-        "react/destructuring-assignment": ["warn", "always"],
-        "react/jsx-fragments": ["off", "syntax"],
-        "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }],
         "camelcase": ["warn", ],
         "comma-dangle": ["warn", {
             "arrays": "always-multiline",
@@ -44,6 +39,12 @@
             "exports": "never",
             "functions": "never"
         }],
-        "linebreak-style": 0
+        "linebreak-style": ["off", ],
+        "max-classes-per-file": ["error", 2],
+        "object-shorthand": ["error", "never"],
+        "no-underscore-dangle": ["off", ],
+        "react/destructuring-assignment": ["warn", "always"],
+        "react/jsx-fragments": ["off", "syntax"],
+        "react/jsx-filename-extension": ["warn", { "extensions": [".js", ".jsx"] }]
     }
 }

--- a/src/renderer/components/SetupTab/index.jsx
+++ b/src/renderer/components/SetupTab/index.jsx
@@ -72,7 +72,7 @@ export default class SetupTab extends React.Component {
       argsValidation: null,
       argsValid: false,
       argsEnabled: null,
-      argsDropdownOptions: null
+      argsDropdownOptions: null,
     };
 
     this.savePythonScript = this.savePythonScript.bind(this);
@@ -119,7 +119,7 @@ export default class SetupTab extends React.Component {
       argsValues: argsValues,
       argsValidation: argsValidation,
       argsEnabled: argsEnabled,
-      argsDropdownOptions: argsDropdownOptions
+      argsDropdownOptions: argsDropdownOptions,
     }, () => {
       this.investValidate();
       this.callUISpecFunctions();
@@ -127,7 +127,7 @@ export default class SetupTab extends React.Component {
   }
 
   /**
-   * Call functions from the UI spec to determine the enabled/disabled 
+   * Call functions from the UI spec to determine the enabled/disabled
    * state and dropdown options for each input, if applicable.
    *
    * @returns {undefined}
@@ -152,7 +152,7 @@ export default class SetupTab extends React.Component {
         // evaluate the function to get a list of dropdown options
         argsDropdownOptions[key] = await dropdownFunctions[key](this.state);
       }
-      this.setState({argsDropdownOptions: argsDropdownOptions});
+      this.setState({ argsDropdownOptions: argsDropdownOptions });
     }
   }
 
@@ -230,7 +230,7 @@ export default class SetupTab extends React.Component {
 
   /** Update state with values and validate a batch of InVEST arguments.
    *
-   * @params {object} argsDict - key: value pairs of InVEST arguments.
+   * @param {object} argsDict - key: value pairs of InVEST arguments.
    */
   batchUpdateArgs(argsDict) {
     const { argsSpec, uiSpec } = this.props;
@@ -308,7 +308,7 @@ export default class SetupTab extends React.Component {
       argsValid,
       argsValidation,
       argsEnabled,
-      argsDropdownOptions
+      argsDropdownOptions,
     } = this.state;
     if (argsValues) {
       const {
@@ -317,7 +317,7 @@ export default class SetupTab extends React.Component {
         sidebarSetupElementId,
         sidebarFooterElementId,
         isRunning,
-        uiSpec
+        uiSpec,
       } = this.props;
 
       const buttonText = (

--- a/src/renderer/components/SetupTab/index.jsx
+++ b/src/renderer/components/SetupTab/index.jsx
@@ -144,10 +144,9 @@ export default class SetupTab extends React.Component {
     if (enabledFunctions) {
       // this model has some fields that are conditionally enabled
       const { argsEnabled } = this.state;
-      for (const key in enabledFunctions) {
-        // evaluate the function to determine if it should be enabled
+      Object.keys(enabledFunctions).forEach((key) => {
         argsEnabled[key] = enabledFunctions[key](this.state);
-      }
+      });
       if (this._isMounted) {
         this.setState({ argsEnabled: argsEnabled });
       }
@@ -156,10 +155,9 @@ export default class SetupTab extends React.Component {
     if (dropdownFunctions) {
       // this model has a dropdown that's dynamically populated
       const { argsDropdownOptions } = this.state;
-      for (const key in dropdownFunctions) {
-        // evaluate the function to get a list of dropdown options
+      await Promise.all(Object.keys(dropdownFunctions).map(async (key) => {
         argsDropdownOptions[key] = await dropdownFunctions[key](this.state);
-      }
+      }));
       if (this._isMounted) {
         this.setState({ argsDropdownOptions: argsDropdownOptions });
       }

--- a/src/renderer/components/SetupTab/index.jsx
+++ b/src/renderer/components/SetupTab/index.jsx
@@ -140,7 +140,7 @@ export default class SetupTab extends React.Component {
       const { argsEnabled } = this.state;
       for (const key in enabledFunctions) {
         // evaluate the function to determine if it should be enabled
-        argsEnabled[key] = await enabledFunctions[key](this.state);
+        argsEnabled[key] = enabledFunctions[key](this.state);
       }
       this.setState({ argsEnabled: argsEnabled });
     }
@@ -158,7 +158,7 @@ export default class SetupTab extends React.Component {
 
   /**
    * n_workers is a special invest arg stored in global settings
-   * 
+   *
    * @param  {object} argsValues - of the shape returned by `initializeArgValues`.
    * @returns {object} copy of original argsValues with an n_workers property.
    */

--- a/src/renderer/components/SetupTab/index.jsx
+++ b/src/renderer/components/SetupTab/index.jsx
@@ -64,10 +64,9 @@ function initializeArgValues(argsSpec, uiSpec, argsDict) {
 
 /** Renders an arguments form, execute button, and save buttons. */
 export default class SetupTab extends React.Component {
-  isMounted = false;
-
   constructor(props) {
     super(props);
+    this._isMounted = false;
 
     this.state = {
       argsValues: null,
@@ -95,7 +94,7 @@ export default class SetupTab extends React.Component {
     * that only needs to compute when this.props.argsSpec changes,
     * not on every re-render.
     */
-    this.isMounted = true;
+    this._isMounted = true;
     const { argsInitValues, argsSpec, uiSpec } = this.props;
 
     const {
@@ -130,7 +129,7 @@ export default class SetupTab extends React.Component {
   }
 
   componentWillUnmount() {
-    this.isMounted = false;
+    this._isMounted = false;
   }
 
   /**
@@ -149,7 +148,7 @@ export default class SetupTab extends React.Component {
         // evaluate the function to determine if it should be enabled
         argsEnabled[key] = enabledFunctions[key](this.state);
       }
-      if (this.isMounted) {
+      if (this._isMounted) {
         this.setState({ argsEnabled: argsEnabled });
       }
     }
@@ -161,7 +160,7 @@ export default class SetupTab extends React.Component {
         // evaluate the function to get a list of dropdown options
         argsDropdownOptions[key] = await dropdownFunctions[key](this.state);
       }
-      if (this.isMounted) {
+      if (this._isMounted) {
         this.setState({ argsDropdownOptions: argsDropdownOptions });
       }
     }
@@ -290,7 +289,7 @@ export default class SetupTab extends React.Component {
         argsValidation[k].valid = true;
         argsValidation[k].validationMessage = '';
       });
-      if (this.isMounted) {
+      if (this._isMounted) {
         this.setState({
           argsValidation: argsValidation,
           argsValid: false,
@@ -306,7 +305,7 @@ export default class SetupTab extends React.Component {
       // It's possible all args were already valid, in which case
       // no validation state has changed and this setState call can
       // be avoided entirely.
-      if (!this.state.argsValid && this.isMounted) {
+      if (!this.state.argsValid && this._isMounted) {
         this.setState({
           argsValidation: argsValidation,
           argsValid: true,

--- a/src/renderer/components/SetupTab/index.jsx
+++ b/src/renderer/components/SetupTab/index.jsx
@@ -17,10 +17,9 @@ import {
 } from '../../server_requests';
 import { argsDictFromObject } from '../../utils';
 
-/** Setup the objects that store InVEST argument values in SetupTab state.
+/** Initialize values of InVEST args based on the model's UI Spec.
  *
- * One object will store input form values and track if the input has been
- * touched. The other object stores data returned by invest validation.
+ * Values initialize with either a complete args dict, or with empty/default values.
  *
  * @param {object} argsSpec - an InVEST model's ARGS_SPEC.args
  * @param {object} uiSpec - the model's UI Spec.

--- a/tests/renderer/setuptab.test.js
+++ b/tests/renderer/setuptab.test.js
@@ -315,33 +315,35 @@ describe('UI spec functionality', () => {
   });
 
   test('expect dropdown options can be dynamic', async () => {
-    const mockGetVectorColumnNames = (state => {
-      if (state.argsValues.arg1.value) {
-        return ['Field1'];
-      } else {
-        return [];
-      }
+    const mockGetVectorColumnNames = ((state) => {
+      // the real getVectorColumnNames returns a Promise
+      return new Promise((resolve) => {
+        if (state.argsValues.arg1.value) {
+          resolve(['Field1']);
+        }
+        resolve([]);
+      });
     });
     const spec = {
       args: {
         arg1: {
           name: 'afoo',
-          type: 'vector'
+          type: 'vector',
         },
         arg2: {
           name: 'bfoo',
           type: 'option_string',
           validation_options: {
-            options: []
-          }
-        }
+            options: [],
+          },
+        },
       },
     };
     const uiSpec = {
       order: [Object.keys(spec.args)],
       dropdownFunctions: {
-        arg2: mockGetVectorColumnNames
-      }
+        arg2: mockGetVectorColumnNames,
+      },
     };
     const { findByLabelText, findByText, queryByText } = renderSetupFromSpec(spec, uiSpec);
     const arg1 = await findByLabelText(RegExp(`${spec.args.arg1.name}`));
@@ -349,8 +351,9 @@ describe('UI spec functionality', () => {
     expect(option).toBeNull();
 
     // check that the dropdown option appears when the text field gets a value
-    fireEvent.change(arg1, { target: { value: 'a vector'}});
-    option = await findByText('Field1');  // will raise an error if not found
+    fireEvent.change(arg1, { target: { value: 'a vector' } });
+    option = await findByText('Field1');
+    expect(option).toBeInTheDocument();
   });
 
   test('Grouping and sorting of args', async () => {

--- a/tests/renderer/setuptab.test.js
+++ b/tests/renderer/setuptab.test.js
@@ -352,8 +352,7 @@ describe('UI spec functionality', () => {
 
     // check that the dropdown option appears when the text field gets a value
     fireEvent.change(arg1, { target: { value: 'a vector' } });
-    option = await findByText('Field1');
-    expect(option).toBeInTheDocument();
+    option = await findByText('Field1'); // will raise an error if not found
   });
 
   test('Grouping and sorting of args', async () => {


### PR DESCRIPTION
This fixes #155 by avoiding `setState` calls after a component has unmounted.

I went with a very simple solution - checking an `isMounted` property - even though it's described as an anti-pattern. https://reactjs.org/blog/2015/12/16/ismounted-antipattern.html

The other recommended solution - making cancellable promises - seemed like a lot more effort and also not really well-suited to the particular async tasks that we have. All async functions technically do return a promise, but our cases (e.g. `investValidate`) doesn't need to return anything, it's main purpose is the `setState` side-effect. So trying to wrap `investValidate` in a cancellable promise didn't seem very straightforward.

So this PR has my proposed solution, but I'm interested to hear more opinions on the pros/cons here. 

I have a solid set of Actions runs on my fork and no sign of that race condition, so I think it's a fix. https://github.com/davemfish/invest-workbench/actions