### PR TITLE
Feature/98 load parameters button vs open button

### DIFF
--- a/src/renderer/app.jsx
+++ b/src/renderer/app.jsx
@@ -247,7 +247,7 @@ export default class App extends React.Component {
                   </Nav.Link>
                 </Navbar.Brand>
               </Col>
-              <Col sm={8} className="pl-1 pr-0">
+              <Col className="pl-1 pr-0 navbar-middle">
                 <Nav
                   justify
                   variant="tabs"
@@ -258,6 +258,8 @@ export default class App extends React.Component {
                 >
                   {investNavItems}
                 </Nav>
+              </Col>
+              <Col className="px-0 text-right navbar-right">
                 {
                   (downloadedNofN)
                     ? (
@@ -268,8 +270,6 @@ export default class App extends React.Component {
                     )
                     : <div />
                 }
-              </Col>
-              <Col sm={1} className="px-0 text-right">
                 {
                   // don't render until after we fetched the data
                   (investSettings)

--- a/src/renderer/app.jsx
+++ b/src/renderer/app.jsx
@@ -11,11 +11,9 @@ import Nav from 'react-bootstrap/Nav';
 import Button from 'react-bootstrap/Button';
 import Row from 'react-bootstrap/Row';
 import Col from 'react-bootstrap/Col';
-import Container from 'react-bootstrap/Container';
 
 import HomeTab from './components/HomeTab';
 import InvestTab from './components/InvestTab';
-import LoadButton from './components/LoadButton';
 import SettingsModal from './components/SettingsModal';
 import {
   DataDownloadModal, DownloadProgressBar
@@ -236,7 +234,7 @@ export default class App extends React.Component {
             onDragOver={dragOverHandlerNone}
           >
             <Row
-              className="w-100 flex-nowrap"
+              className="w-100 flex-nowrap mr-0"
             >
               <Col sm={3} className="px-0">
                 <Navbar.Brand onDragOver={dragOverHandlerNone}>
@@ -249,7 +247,7 @@ export default class App extends React.Component {
                   </Nav.Link>
                 </Navbar.Brand>
               </Col>
-              <Col sm={7} className="pl-1 pr-0">
+              <Col sm={8} className="pl-1 pr-0">
                 <Nav
                   justify
                   variant="tabs"
@@ -271,11 +269,7 @@ export default class App extends React.Component {
                     : <div />
                 }
               </Col>
-              <Col sm={2} className="px-0 text-right">
-                <LoadButton
-                  openInvestModel={this.openInvestModel}
-                  batchUpdateArgs={this.batchUpdateArgs}
-                />
+              <Col sm={1} className="px-0 text-right">
                 {
                   // don't render until after we fetched the data
                   (investSettings)
@@ -300,6 +294,7 @@ export default class App extends React.Component {
                 investList={investList}
                 openInvestModel={this.openInvestModel}
                 recentJobs={recentJobs}
+                batchUpdateArgs={this.batchUpdateArgs}
               />
             </TabPane>
             {investTabPanes}

--- a/src/renderer/app.jsx
+++ b/src/renderer/app.jsx
@@ -237,11 +237,10 @@ export default class App extends React.Component {
               className="w-100 flex-nowrap mr-0"
             >
               <Col sm={3} className="px-0">
-                <Navbar.Brand onDragOver={dragOverHandlerNone}>
+                <Navbar.Brand>
                   <Nav.Link
                     onSelect={this.switchTabs}
                     eventKey="home"
-                    onDragOver={dragOverHandlerNone}
                   >
                     InVEST
                   </Nav.Link>
@@ -254,7 +253,6 @@ export default class App extends React.Component {
                   className="mr-auto"
                   activeKey={activeTab}
                   onSelect={this.switchTabs}
-                  onDragOver={dragOverHandlerNone}
                 >
                   {investNavItems}
                 </Nav>
@@ -288,7 +286,10 @@ export default class App extends React.Component {
             </Row>
           </Navbar>
 
-          <TabContent id="top-tab-content">
+          <TabContent
+            id="top-tab-content"
+            onDragOver={dragOverHandlerNone}
+          >
             <TabPane eventKey="home" title="Home">
               <HomeTab
                 investList={investList}

--- a/src/renderer/components/DataDownloadModal/index.jsx
+++ b/src/renderer/components/DataDownloadModal/index.jsx
@@ -11,6 +11,7 @@ import Table from 'react-bootstrap/Table';
 
 import Expire from '../Expire';
 import sampledataRegistry from '../../sampledata_registry.json';
+import { ipcMainChannels } from '../../../main/ipcMainChannels';
 
 const logger = window.Workbench.getLogger(__filename.split('/').slice(-1)[0]);
 
@@ -50,12 +51,12 @@ export class DataDownloadModal extends React.Component {
     // even though the idea is to save files, here we just want to chooose
     // a directory, so must use OpenDialog.
     const data = await ipcRenderer.invoke(
-      'show-open-dialog',
+      ipcMainChannels.SHOW_OPEN_DIALOG,
       { properties: ['openDirectory'] }
     );
     if (data.filePaths.length) {
       ipcRenderer.send(
-        'download-url',
+        ipcMainChannels.DOWNLOAD_URL,
         this.state.selectedLinksArray,
         data.filePaths[0]
       );

--- a/src/renderer/components/HomeTab/index.jsx
+++ b/src/renderer/components/HomeTab/index.jsx
@@ -8,7 +8,7 @@ import Container from 'react-bootstrap/Container';
 import Col from 'react-bootstrap/Col';
 import Row from 'react-bootstrap/Row';
 
-import LoadButton from '../LoadButton';
+import OpenButton from '../OpenButton';
 import InvestJob from '../../InvestJob';
 
 const logger = window.Workbench.getLogger(__filename.split('/').slice(-2).join('/'));
@@ -150,7 +150,7 @@ class RecentInvestJobs extends React.PureComponent {
           <h4 className="d-inline-block">
             Recent runs:
           </h4>
-          <LoadButton
+          <OpenButton
             className="float-right"
             openInvestModel={this.props.openInvestModel}
             batchUpdateArgs={this.props.batchUpdateArgs}

--- a/src/renderer/components/HomeTab/index.jsx
+++ b/src/renderer/components/HomeTab/index.jsx
@@ -147,27 +147,27 @@ class RecentInvestJobs extends React.PureComponent {
     return (
       <Container>
         <div className="mb-1">
-          <h4 className="d-inline-block">
-            Recent runs:
-          </h4>
+          {recentButtons.length
+            ? (
+              <h4 className="d-inline-block">
+                Recent runs:
+              </h4>
+            )
+            : (
+              <div className="d-inline-block">
+                Try the <b>Open</b> button to setup a model from a sample 
+                datastack file (.json) or from an InVEST model's logfile (.txt)
+              </div>
+            )}
           <OpenButton
             className="float-right"
             openInvestModel={this.props.openInvestModel}
             batchUpdateArgs={this.props.batchUpdateArgs}
           />
         </div>
-        {recentButtons.length
-          ? (
-            <React.Fragment>
-              {recentButtons}
-            </React.Fragment>
-          )
-          : (
-            <div>
-              Try the <b>Open</b> button to setup a model from a sample 
-              datastack file (.json) or from an invest model's logfile (.txt)
-            </div>
-          )}
+        <React.Fragment>
+          {recentButtons}
+        </React.Fragment>
       </Container>
     );
   }

--- a/src/renderer/components/HomeTab/index.jsx
+++ b/src/renderer/components/HomeTab/index.jsx
@@ -8,6 +8,7 @@ import Container from 'react-bootstrap/Container';
 import Col from 'react-bootstrap/Col';
 import Row from 'react-bootstrap/Row';
 
+import LoadButton from '../LoadButton';
 import InvestJob from '../../InvestJob';
 
 const logger = window.Workbench.getLogger(__filename.split('/').slice(-2).join('/'));
@@ -145,9 +146,16 @@ class RecentInvestJobs extends React.PureComponent {
 
     return (
       <Container>
-        <h4>
-          Recent runs:
-        </h4>
+        <div className="mb-1">
+          <h4 className="d-inline-block">
+            Recent runs:
+          </h4>
+          <LoadButton
+            className="float-right"
+            openInvestModel={this.props.openInvestModel}
+            batchUpdateArgs={this.props.batchUpdateArgs}
+          />
+        </div>
         {recentButtons.length
           ? (
             <React.Fragment>
@@ -156,8 +164,6 @@ class RecentInvestJobs extends React.PureComponent {
           )
           : (
             <div>
-              No recent InVEST runs yet.
-              <br />
               Try the <b>Open</b> button to setup a model from a sample 
               datastack file (.json) or from an invest model's logfile (.txt)
             </div>

--- a/src/renderer/components/InvestTab/index.jsx
+++ b/src/renderer/components/InvestTab/index.jsx
@@ -15,7 +15,6 @@ import SetupTab from '../SetupTab';
 import LogTab from '../LogTab';
 import ResourcesLinks from '../ResourcesLinks';
 import { getSpec } from '../../server_requests';
-import { dragOverHandlerNone } from '../../utils';
 
 const logger = window.Workbench.getLogger(__filename.split('/').slice(-1)[0]);
 
@@ -207,7 +206,6 @@ export default class InvestTab extends React.Component {
           <Col
             md={3}
             className="invest-sidebar-col"
-            onDragOver={dragOverHandlerNone}
           >
             <Nav
               className="flex-column"

--- a/src/renderer/components/InvestTab/index.jsx
+++ b/src/renderer/components/InvestTab/index.jsx
@@ -15,6 +15,7 @@ import SetupTab from '../SetupTab';
 import LogTab from '../LogTab';
 import ResourcesLinks from '../ResourcesLinks';
 import { getSpec } from '../../server_requests';
+import { ipcMainChannels } from '../../../main/ipcMainChannels';
 
 const logger = window.Workbench.getLogger(__filename.split('/').slice(-1)[0]);
 
@@ -148,7 +149,7 @@ export default class InvestTab extends React.Component {
     });
 
     ipcRenderer.send(
-      'invest-run',
+      ipcMainChannels.INVEST_RUN,
       job.metadata.modelRunName,
       this.state.modelSpec.module,
       args,
@@ -158,7 +159,7 @@ export default class InvestTab extends React.Component {
   }
 
   terminateInvestProcess() {
-    ipcRenderer.send('invest-kill', this.state.workspaceDir);
+    ipcRenderer.send(ipcMainChannels.INVEST_KILL, this.state.workspaceDir);
     this.setState({
       logStdErr: 'Run Canceled'
     });

--- a/src/renderer/components/LoadButton/index.jsx
+++ b/src/renderer/components/LoadButton/index.jsx
@@ -8,7 +8,6 @@ import Tooltip from 'react-bootstrap/Tooltip';
 
 import InvestJob from '../../InvestJob';
 import { fetchDatastackFromFile } from '../../server_requests';
-import { dragOverHandlerNone } from '../../utils';
 
 /**
  * Render a button that loads args from a datastack, parameterset, or logfile.
@@ -45,7 +44,6 @@ export default class LoadButton extends React.Component {
           className={this.props.className}
           onClick={this.browseFile}
           variant="outline-dark"
-          onDragOver={dragOverHandlerNone}
         >
           Open
         </Button>

--- a/src/renderer/components/LoadButton/index.jsx
+++ b/src/renderer/components/LoadButton/index.jsx
@@ -42,7 +42,7 @@ export default class LoadButton extends React.Component {
         overlay={<Tooltip>{tipText}</Tooltip>}
       >
         <Button
-          className="mx-3"
+          className={this.props.className}
           onClick={this.browseFile}
           variant="outline-dark"
           onDragOver={dragOverHandlerNone}

--- a/src/renderer/components/OpenButton/index.jsx
+++ b/src/renderer/components/OpenButton/index.jsx
@@ -13,7 +13,7 @@ import { fetchDatastackFromFile } from '../../server_requests';
  * Render a button that loads args from a datastack, parameterset, or logfile.
  * Opens a native OS filesystem dialog to browse to a file.
  */
-export default class LoadButton extends React.Component {
+export default class OpenButton extends React.Component {
   constructor(props) {
     super(props);
     this.browseFile = this.browseFile.bind(this);
@@ -52,6 +52,6 @@ export default class LoadButton extends React.Component {
   }
 }
 
-LoadButton.propTypes = {
+OpenButton.propTypes = {
   openInvestModel: PropTypes.func.isRequired,
 };

--- a/src/renderer/components/OpenButton/index.jsx
+++ b/src/renderer/components/OpenButton/index.jsx
@@ -34,7 +34,7 @@ export default class OpenButton extends React.Component {
   }
 
   render() {
-    const tipText = 'Browse to a datastack (.json) or invest logfile (.txt)';
+    const tipText = 'Browse to a datastack (.json) or InVEST logfile (.txt)';
     return (
       <OverlayTrigger
         placement="left"

--- a/src/renderer/components/OpenButton/index.jsx
+++ b/src/renderer/components/OpenButton/index.jsx
@@ -8,6 +8,7 @@ import Tooltip from 'react-bootstrap/Tooltip';
 
 import InvestJob from '../../InvestJob';
 import { fetchDatastackFromFile } from '../../server_requests';
+import { ipcMainChannels } from '../../../main/ipcMainChannels';
 
 /**
  * Render a button that loads args from a datastack, parameterset, or logfile.
@@ -20,7 +21,7 @@ export default class OpenButton extends React.Component {
   }
 
   async browseFile() {
-    const data = await ipcRenderer.invoke('show-open-dialog');
+    const data = await ipcRenderer.invoke(ipcMainChannels.SHOW_OPEN_DIALOG);
     if (data.filePaths.length) {
       const datastack = await fetchDatastackFromFile(data.filePaths[0]);
       const job = new InvestJob({

--- a/src/renderer/components/SaveFileButton/index.jsx
+++ b/src/renderer/components/SaveFileButton/index.jsx
@@ -4,6 +4,8 @@ import PropTypes from 'prop-types';
 
 import Button from 'react-bootstrap/Button';
 
+import { ipcMainChannels } from '../../../main/ipcMainChannels';
+
 /** Render a button that saves current args to a datastack json.
  * Opens an native OS filesystem dialog to browse to a save location.
  * Creates the JSON using datastack.py.
@@ -15,7 +17,10 @@ export default class SaveFileButton extends React.Component {
   }
 
   async browseSaveFile(event) {
-    const data = await ipcRenderer.invoke('show-save-dialog', { defaultPath: this.props.defaultTargetPath });
+    const data = await ipcRenderer.invoke(
+      ipcMainChannels.SHOW_SAVE_DIALOG,
+      { defaultPath: this.props.defaultTargetPath }
+    );
     if (data.filePath) {
       this.props.func(data.filePath);
     }

--- a/src/renderer/components/SaveFileButton/index.jsx
+++ b/src/renderer/components/SaveFileButton/index.jsx
@@ -4,8 +4,6 @@ import PropTypes from 'prop-types';
 
 import Button from 'react-bootstrap/Button';
 
-import { dragOverHandlerNone } from '../../utils';
-
 /** Render a button that saves current args to a datastack json.
  * Opens an native OS filesystem dialog to browse to a save location.
  * Creates the JSON using datastack.py.
@@ -28,7 +26,6 @@ export default class SaveFileButton extends React.Component {
       <Button
         onClick={this.browseSaveFile}
         variant="link"
-        onDragOver={dragOverHandlerNone}
       >
         {this.props.title}
       </Button>

--- a/src/renderer/components/SettingsModal/index.jsx
+++ b/src/renderer/components/SettingsModal/index.jsx
@@ -7,7 +7,6 @@ import Form from 'react-bootstrap/Form';
 import Button from 'react-bootstrap/Button';
 import Modal from 'react-bootstrap/Modal';
 
-import { dragOverHandlerNone } from '../../utils';
 import { getDefaultSettings } from './SettingsStorage';
 
 /** Validate that n_workers is an acceptable value for Taskgraph.
@@ -130,7 +129,6 @@ export default class SettingsModal extends React.Component {
         <Button
           as={CustomButton}
           onClick={this.handleShow}
-          onDragOver={dragOverHandlerNone}
         />
 
         <Modal show={this.state.show} onHide={this.handleClose}>

--- a/src/renderer/components/SetupTab/ArgsForm/index.jsx
+++ b/src/renderer/components/SetupTab/ArgsForm/index.jsx
@@ -44,14 +44,7 @@ export default class ArgsForm extends React.Component {
       alert('Only drop one file at a time.');
       return;
     }
-    const datastack = await fetchDatastackFromFile(fileList[0].path);
-
-    if (datastack.module_name === this.props.pyModuleName) {
-      this.props.batchUpdateArgs(datastack.args);
-    } else {
-      alert(
-        `Parameter/Log file for ${datastack.module_name} does not match this model: ${this.props.pyModuleName}`);
-    }
+    this.props.loadParametersFromFile(fileList[0].path);
   }
 
   /** Handle drag enter events for the Form elements. */
@@ -202,6 +195,5 @@ ArgsForm.propTypes = {
     PropTypes.arrayOf(PropTypes.string),
   ).isRequired,
   updateArgValues: PropTypes.func.isRequired,
-  batchUpdateArgs: PropTypes.func.isRequired,
-  pyModuleName: PropTypes.string.isRequired,
+  loadParametersFromFile: PropTypes.func.isRequired,
 };

--- a/src/renderer/components/SetupTab/ArgsForm/index.jsx
+++ b/src/renderer/components/SetupTab/ArgsForm/index.jsx
@@ -5,8 +5,8 @@ import { ipcRenderer } from 'electron'; // eslint-disable-line import/no-extrane
 import Form from 'react-bootstrap/Form';
 
 import ArgInput from '../ArgInput';
-import { fetchDatastackFromFile } from '../../../server_requests';
 import { boolStringToBoolean } from '../../../utils';
+import { ipcMainChannels } from '../../../../main/ipcMainChannels';
 
 /** Prevent the default case for onDragOver so onDrop event will be fired. */
 function dragOverHandler(event) {
@@ -27,7 +27,7 @@ export default class ArgsForm extends React.Component {
     this.dragEnterHandler = this.dragEnterHandler.bind(this);
     this.dragLeaveHandler = this.dragLeaveHandler.bind(this);
     this.formRef = React.createRef(); // For dragging CSS
-    this.dragDepth = 0;  // To determine Form dragging CSS 
+    this.dragDepth = 0; // To determine Form dragging CSS
   }
 
   async onArchiveDragDrop(event) {
@@ -37,7 +37,7 @@ export default class ArgsForm extends React.Component {
     // No longer dragging so reset dragging depth and remove CSS
     this.dragDepth = 0;
     const formElement = this.formRef.current;
-    formElement.classList.remove("dragging");
+    formElement.classList.remove('dragging');
 
     const fileList = event.dataTransfer.files;
     if (fileList.length !== 1) {
@@ -54,8 +54,8 @@ export default class ArgsForm extends React.Component {
     event.dataTransfer.dropEffect = 'copy';
     this.dragDepth++;
     const formElement = this.formRef.current;
-    if (!formElement.classList.contains("dragging")) {
-      formElement.classList.add("dragging");
+    if (!formElement.classList.contains('dragging')) {
+      formElement.classList.add('dragging');
     }
   }
 
@@ -65,8 +65,8 @@ export default class ArgsForm extends React.Component {
     event.stopPropagation();
     this.dragDepth--;
     const formElement = this.formRef.current;
-    if (this.dragDepth <= 0 ) {
-        formElement.classList.remove("dragging");
+    if (this.dragDepth <= 0) {
+      formElement.classList.remove('dragging');
     }
   }
 
@@ -74,7 +74,7 @@ export default class ArgsForm extends React.Component {
   inputDropHandler(event) {
     event.preventDefault();
     event.stopPropagation();
-    event.target.classList.remove("input-dragging");
+    event.target.classList.remove('input-dragging');
     // Don't take any action on disabled elements
     if (event.target.disabled) {
       return;
@@ -87,7 +87,7 @@ export default class ArgsForm extends React.Component {
     } else if (fileList.length === 1) {
       this.props.updateArgValues(name, fileList[0].path);
     } else {
-      throw "Error handling input file drop"
+      throw new Error('Error handling input file drop');
     }
   }
 
@@ -109,9 +109,12 @@ export default class ArgsForm extends React.Component {
     const { name, value } = event.target; // the arg's key and type
     const prop = (value === 'directory') ? 'openDirectory' : 'openFile';
     // TODO: could add more filters based on argType (e.g. only show .csv)
-    const data = await ipcRenderer.invoke('show-open-dialog', { properties: [prop] });
+    const data = await ipcRenderer.invoke(
+      ipcMainChannels.SHOW_OPEN_DIALOG, { properties: [prop] }
+    );
     if (data.filePaths.length) {
-      this.props.updateArgValues(name, data.filePaths[0]); // dialog defaults allow only 1 selection
+      // dialog defaults allow only 1 selection
+      this.props.updateArgValues(name, data.filePaths[0]);
     }
   }
 

--- a/src/renderer/components/SetupTab/SetupButtons/index.jsx
+++ b/src/renderer/components/SetupTab/SetupButtons/index.jsx
@@ -3,7 +3,6 @@ import React from 'react';
 import Button from 'react-bootstrap/Button';
 
 import SaveFileButton from '../../SaveFileButton';
-import { dragOverHandlerNone } from '../../../utils';
 
 export function SaveParametersButtons(props) {
   return (
@@ -30,7 +29,6 @@ export function RunButton(props) {
       size="lg"
       onClick={props.wrapInvestExecute}
       disabled={props.disabled}
-      onDragOver={dragOverHandlerNone}
     >
       {props.buttonText}
     </Button>

--- a/src/renderer/components/SetupTab/index.jsx
+++ b/src/renderer/components/SetupTab/index.jsx
@@ -221,7 +221,8 @@ export default class SetupTab extends React.Component {
       this.batchUpdateArgs(datastack.args);
     } else {
       alert(
-        `Parameter/Log file for ${datastack.module_name} does not match this model: ${this.props.pyModuleName}`);
+        `Datastack/Logfile for ${datastack.model_human_name} model does not match this model.`
+      );
     }
   }
 
@@ -389,7 +390,7 @@ export default class SetupTab extends React.Component {
               delay={{ show: 250, hide: 400 }}
               overlay={(
                 <Tooltip>
-                  Browse to a datastack (.json) or invest logfile (.txt)
+                  Browse to a datastack (.json) or InVEST logfile (.txt)
                 </Tooltip>
               )}
             >

--- a/src/renderer/components/SetupTab/index.jsx
+++ b/src/renderer/components/SetupTab/index.jsx
@@ -21,6 +21,7 @@ import {
   writeParametersToFile
 } from '../../server_requests';
 import { argsDictFromObject } from '../../utils';
+import { ipcMainChannels } from '../../../main/ipcMainChannels';
 
 /** Initialize values of InVEST args based on the model's UI Spec.
  *
@@ -225,7 +226,7 @@ export default class SetupTab extends React.Component {
   }
 
   async browseForDatastack() {
-    const data = await ipcRenderer.invoke('show-open-dialog');
+    const data = await ipcRenderer.invoke(ipcMainChannels.SHOW_OPEN_DIALOG);
     if (data.filePaths.length) {
       this.loadParametersFromFile(data.filePaths[0]);
     }

--- a/src/renderer/components/SetupTab/index.jsx
+++ b/src/renderer/components/SetupTab/index.jsx
@@ -221,7 +221,7 @@ export default class SetupTab extends React.Component {
       this.batchUpdateArgs(datastack.args);
     } else {
       alert(
-        `Datastack/Logfile for ${datastack.model_human_name} model does not match this model.`
+        `Datastack/Logfile for ${datastack.model_human_name} does not match this model.`
       );
     }
   }

--- a/src/renderer/components/SetupTab/index.jsx
+++ b/src/renderer/components/SetupTab/index.jsx
@@ -345,7 +345,6 @@ export default class SetupTab extends React.Component {
     if (argsValues) {
       const {
         argsSpec,
-        pyModuleName,
         sidebarSetupElementId,
         sidebarFooterElementId,
         isRunning,

--- a/src/renderer/components/SetupTab/index.jsx
+++ b/src/renderer/components/SetupTab/index.jsx
@@ -20,7 +20,7 @@ import {
   saveToPython,
   writeParametersToFile
 } from '../../server_requests';
-import { argsDictFromObject, dragOverHandlerNone } from '../../utils';
+import { argsDictFromObject } from '../../utils';
 
 /** Initialize values of InVEST args based on the model's UI Spec.
  *
@@ -369,7 +369,7 @@ export default class SetupTab extends React.Component {
           : <span>Run</span>
       );
       return (
-        <Container fluid onDragOver={dragOverHandlerNone}>
+        <Container fluid>
           <Row>
             <ArgsForm
               argsSpec={argsSpec}

--- a/src/renderer/components/SetupTab/index.jsx
+++ b/src/renderer/components/SetupTab/index.jsx
@@ -1,9 +1,11 @@
+import { ipcRenderer } from 'electron';
 import React from 'react';
 import PropTypes from 'prop-types';
 
 import Container from 'react-bootstrap/Container';
 import Spinner from 'react-bootstrap/Spinner';
 import Row from 'react-bootstrap/Row';
+import Button from 'react-bootstrap/Button';
 
 import Portal from '../Portal';
 import ArgsForm from './ArgsForm';
@@ -11,11 +13,12 @@ import {
   RunButton, SaveParametersButtons
 } from './SetupButtons';
 import {
+  fetchDatastackFromFile,
   fetchValidation,
   saveToPython,
   writeParametersToFile
 } from '../../server_requests';
-import { argsDictFromObject } from '../../utils';
+import { argsDictFromObject, dragOverHandlerNone } from '../../utils';
 
 /** Initialize values of InVEST args based on the model's UI Spec.
  *
@@ -83,6 +86,8 @@ export default class SetupTab extends React.Component {
     this.batchUpdateArgs = this.batchUpdateArgs.bind(this);
     this.insertNWorkers = this.insertNWorkers.bind(this);
     this.callUISpecFunctions = this.callUISpecFunctions.bind(this);
+    this.browseForDatastack = this.browseForDatastack.bind(this);
+    this.loadParametersFromFile = this.loadParametersFromFile.bind(this);
   }
 
   componentDidMount() {
@@ -204,6 +209,24 @@ export default class SetupTab extends React.Component {
       args: JSON.stringify(args),
     };
     writeParametersToFile(payload);
+  }
+
+  async loadParametersFromFile(filepath) {
+    const datastack = await fetchDatastackFromFile(filepath);
+
+    if (datastack.module_name === this.props.pyModuleName) {
+      this.batchUpdateArgs(datastack.args);
+    } else {
+      alert(
+        `Parameter/Log file for ${datastack.module_name} does not match this model: ${this.props.pyModuleName}`);
+    }
+  }
+
+  async browseForDatastack() {
+    const data = await ipcRenderer.invoke('show-open-dialog');
+    if (data.filePaths.length) {
+      this.loadParametersFromFile(data.filePaths[0]);
+    }
   }
 
   wrapInvestExecute() {
@@ -345,7 +368,7 @@ export default class SetupTab extends React.Component {
           : <span>Run</span>
       );
       return (
-        <Container fluid>
+        <Container fluid onDragOver={dragOverHandlerNone}>
           <Row>
             <ArgsForm
               argsSpec={argsSpec}
@@ -354,12 +377,17 @@ export default class SetupTab extends React.Component {
               argsEnabled={argsEnabled}
               argsDropdownOptions={argsDropdownOptions}
               argsOrder={uiSpec.order}
-              pyModuleName={pyModuleName}
               updateArgValues={this.updateArgValues}
-              batchUpdateArgs={this.batchUpdateArgs}
+              loadParametersFromFile={this.loadParametersFromFile}
             />
           </Row>
           <Portal elId={sidebarSetupElementId}>
+            <Button
+              onClick={this.browseForDatastack}
+              variant="link"
+            >
+              Load parameters from file
+            </Button>
             <SaveParametersButtons
               savePythonScript={this.savePythonScript}
               saveJsonFile={this.saveJsonFile}

--- a/src/renderer/components/SetupTab/index.jsx
+++ b/src/renderer/components/SetupTab/index.jsx
@@ -6,6 +6,8 @@ import Container from 'react-bootstrap/Container';
 import Spinner from 'react-bootstrap/Spinner';
 import Row from 'react-bootstrap/Row';
 import Button from 'react-bootstrap/Button';
+import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
+import Tooltip from 'react-bootstrap/Tooltip';
 
 import Portal from '../Portal';
 import ArgsForm from './ArgsForm';
@@ -381,12 +383,22 @@ export default class SetupTab extends React.Component {
             />
           </Row>
           <Portal elId={sidebarSetupElementId}>
-            <Button
-              onClick={this.browseForDatastack}
-              variant="link"
+            <OverlayTrigger
+              placement="right"
+              delay={{ show: 250, hide: 400 }}
+              overlay={(
+                <Tooltip>
+                  Browse to a datastack (.json) or invest logfile (.txt)
+                </Tooltip>
+              )}
             >
-              Load parameters from file
-            </Button>
+              <Button
+                onClick={this.browseForDatastack}
+                variant="link"
+              >
+                Load parameters from file
+              </Button>
+            </OverlayTrigger>
             <SaveParametersButtons
               savePythonScript={this.savePythonScript}
               saveJsonFile={this.saveJsonFile}

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -3,6 +3,7 @@ import React from 'react';
 import ReactDom from 'react-dom';
 
 import App from './app';
+import { ipcMainChannels } from '../main/ipcMainChannels';
 
 const logger = window.Workbench.getLogger(__filename.split('/').slice(-1)[0]);
 
@@ -13,17 +14,17 @@ let rightClickPosition = null;
 window.addEventListener('contextmenu', (e) => {
   e.preventDefault();
   rightClickPosition = { x: e.x, y: e.y };
-  ipcRenderer.send('show-context-menu', rightClickPosition);
+  ipcRenderer.send(ipcMainChannels.SHOW_CONTEXT_MENU, rightClickPosition);
 });
 
 function render(isFirstRun) {
   ReactDom.render(
-    <App isFirstRun={isFirstRun}/>,
+    <App isFirstRun={isFirstRun} />,
     document.getElementById('App')
-  )
-};
+  );
+}
 
-ipcRenderer.invoke('is-first-run')
+ipcRenderer.invoke(ipcMainChannels.IS_FIRST_RUN)
   .then((response) => {
     render(response);
   });

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -228,7 +228,7 @@ body {
 	flex-direction: column;
 	flex-wrap: nowrap;
 	align-items: flex-start;
-	padding-left: 2rem;
+	padding-left: 1.5rem;
 }
 
 /* Resources Links */

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -23,6 +23,16 @@ body {
 	padding-bottom: 0;
 }
 
+.navbar-middle {
+	flex-shrink: 1;
+	min-width: 0;
+}
+
+.navbar-right {
+	max-width: fit-content;
+	margin-left: 0.5rem;
+}
+
 .navbar-brand .nav-link {
 	color: var(--invest-green);
 	font-weight: 600;
@@ -83,6 +93,7 @@ body {
 }
 
 .progress {
+	display: inline-flex;
 	height: 2rem;
 	font-size: 1rem;
 	background-color: #aeb1b3;

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -198,7 +198,7 @@ body {
 	display: flex;
 	flex-direction: column;
 	padding-right: 0;
-	min-width: 250px;
+	min-width: fit-content;
 }
 
 .invest-sidebar-col .nav-link {
@@ -229,6 +229,10 @@ body {
 	flex-wrap: nowrap;
 	align-items: flex-start;
 	padding-left: 1.5rem;
+}
+
+.sidebar-setup .btn {
+	white-space: nowrap;
 }
 
 /* Resources Links */

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -135,6 +135,7 @@ body {
 	flex-direction: column;
 	height: 87vh;
 	overflow-y: auto;
+	margin-top: 15px;
 }
 
 .recent-job-card {

--- a/tests/renderer/app.test.js
+++ b/tests/renderer/app.test.js
@@ -283,7 +283,7 @@ describe('Display recently executed InVEST jobs', () => {
       <App />
     );
 
-    const node = await findByText(/No recent InVEST runs/);
+    const node = await findByText(/button to setup a model/);
     expect(node).toBeInTheDocument();
   });
 
@@ -309,7 +309,7 @@ describe('Display recently executed InVEST jobs', () => {
     });
     fireEvent.click(getByTitle('settings'));
     fireEvent.click(getByText('Clear'));
-    const node = await findByText(/No recent InVEST runs/);
+    const node = await findByText(/button to setup a model/);
     expect(node).toBeInTheDocument();
   });
 });

--- a/tests/renderer/investtab.test.js
+++ b/tests/renderer/investtab.test.js
@@ -160,7 +160,7 @@ describe('Save InVEST Model Setup Buttons', () => {
     const loadButton = await findByText('Load parameters from file');
     // test the tooltip before we click
     userEvent.hover(loadButton);
-    const hoverText = 'Browse to a datastack (.json) or invest logfile (.txt)';
+    const hoverText = 'Browse to a datastack (.json) or InVEST logfile (.txt)';
     expect(await findByText(hoverText)).toBeInTheDocument();
     userEvent.unhover(loadButton);
     await waitFor(() => {

--- a/tests/renderer/investtab.test.js
+++ b/tests/renderer/investtab.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { ipcRenderer } from 'electron';
 import { fireEvent, render, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import userEvent from '@testing-library/user-event';
 
 import InvestTab from '../../src/renderer/components/InvestTab';
 import SetupTab from '../../src/renderer/components/SetupTab';
@@ -154,9 +155,17 @@ describe('Save InVEST Model Setup Buttons', () => {
     };
     ipcRenderer.invoke.mockResolvedValue(mockDialogData);
 
-    const { findByText, findByLabelText } = renderInvestTab();
+    const { findByText, findByLabelText, queryByText } = renderInvestTab();
 
     const loadButton = await findByText('Load parameters from file');
+    // test the tooltip before we click
+    userEvent.hover(loadButton);
+    const hoverText = 'Browse to a datastack (.json) or invest logfile (.txt)';
+    expect(await findByText(hoverText)).toBeInTheDocument();
+    userEvent.unhover(loadButton);
+    await waitFor(() => {
+      expect(queryByText(hoverText)).toBeNull();
+    });
     fireEvent.click(loadButton);
 
     const input1 = await findByLabelText(spec.args.workspace.name);

--- a/tests/renderer/openbutton.test.js
+++ b/tests/renderer/openbutton.test.js
@@ -15,7 +15,7 @@ test('Open File: displays a tooltip on hover', async () => {
 
   const openButton = await findByRole('button', { name: 'Open' });
   userEvent.hover(openButton);
-  const hoverText = 'Browse to a datastack (.json) or invest logfile (.txt)';
+  const hoverText = 'Browse to a datastack (.json) or InVEST logfile (.txt)';
   expect(await findByText(hoverText)).toBeInTheDocument();
   userEvent.unhover(openButton);
   await waitFor(() => {

--- a/tests/renderer/openbutton.test.js
+++ b/tests/renderer/openbutton.test.js
@@ -3,11 +3,11 @@ import { render, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import userEvent from '@testing-library/user-event';
 
-import LoadButton from '../../src/renderer/components/LoadButton';
+import OpenButton from '../../src/renderer/components/OpenButton';
 
 test('Open File: displays a tooltip on hover', async () => {
   const { findByRole, findByText, queryByText } = render(
-    <LoadButton
+    <OpenButton
       openInvestModel={() => {}}
       batchUpdateArgs={() => {}}
     />


### PR DESCRIPTION
This PR fixes #98 and #112 . It moves the "Open" button out of the Navbar and onto the Home tab. And it creates a new "Load parameters from file" button available under the Setup menu next the "Save as..." buttons. The new load button has essentially the same behavior as a drag-and-drop onto the ArgsForm.

This PR also does a couple other misc items that became apparent:
* Fixed a bug introduced in #154 where the sample data download progress bar was not being displayed inline in the navbar during downloads.
* Moved the `onDragOver` property -- that we use to set the default dragover icon to "None" -- up to the top-level node that accepts it. That way we don't need to add this property to so many individual components. Our dragOver behavior still works everywhere it should. Presumably the properties on children override the one's on their parent.
* Replaced IPC channel strings with the constants that we defined during #147 - all the ipcRenderer calls still had hardcoded strings.