### PR TITLE
Task/51 usage logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "invest": {
     "bucket": "releases.naturalcapitalproject.org",
     "fork": "natcap",
-    "version": "3.9.1.post321+gf8ee8ff7",
+    "version": "3.9.1.post464+gb05dea2e",
     "target": {
       "macos": "mac_invest_binaries.zip",
       "windows": "windows_invest_binaries.zip"

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@testing-library/react": "^12.0.0",
     "@testing-library/user-event": "^12.8.3",
     "babel-eslint": "^10.1.0",
-    "electron": "^13.1.4",
+    "electron": "^15.1.1",
     "electron-builder": "^22.10.5",
     "electron-devtools-installer": "^3.2.0",
     "eslint": "^7.21.0",

--- a/src/main/investUsageLogger.js
+++ b/src/main/investUsageLogger.js
@@ -1,0 +1,101 @@
+import crypto from 'crypto';
+
+import { getLogger } from '../logger';
+import pkg from '../../package.json';
+
+const logger = getLogger(__filename.split('/').slice(-1)[0]);
+const WORKBENCH_VERSION = pkg.version;
+const HOSTNAME = 'http://localhost';
+
+
+// /** Send request to log invest model usage.
+//  *
+//  * @param {string} modelPyName - identifies the invest model's python module
+//  * @param {object} args - key: value pairs representing the model's args dict
+//  * @param {string} sessionId - a UUID version4 id to link start and exit rows.
+//  */
+// function logModelStart(modelPyName, args, sessionId) {
+//   try {
+//     logger.debug('logging model start');
+//     fetch(`${HOSTNAME}:${process.env.PORT}/log_model_start`, {
+//       method: 'post',
+//       body: JSON.stringify({
+//         model_pyname: modelPyName,
+//         model_args: JSON.stringify(args),
+//         invest_interface: `Workbench ${WORKBENCH_VERSION}`,
+//         session_id: sessionId,
+//       }),
+//       headers: { 'Content-Type': 'application/json' },
+//     });
+//   } catch (error) {
+//     logger.warn('Failed to log model start');
+//     logger.warn(error.stack);
+//   }
+// }
+
+// /** Send request to log invest model exit status.
+//  *
+//  * @param {string} sessionId - a UUID version4 id to link start and exit rows.
+//  * @param {string} status - exit status, typically the python traceback.
+//  */
+// function logModelExit(sessionId, status) {
+//   try {
+//     logger.debug('logging model exit');
+//     fetch(`${HOSTNAME}:${process.env.PORT}/log_model_exit`, {
+//       method: 'post',
+//       body: JSON.stringify({
+//         session_id: sessionId,
+//         status: status,
+//       }),
+//       headers: { 'Content-Type': 'application/json' },
+//     });
+//   } catch (error) {
+//     logger.warn('Failed to log model exit');
+//     logger.warn(error.stack);
+//   }
+// }
+
+export default function investUsageLogger() {
+  const sessionId = crypto.randomUUID();
+
+  function start(modelPyName, args) {
+    try {
+      logger.debug('logging model start');
+      fetch(`${HOSTNAME}:${process.env.PORT}/log_model_start`, {
+        method: 'post',
+        body: JSON.stringify({
+          model_pyname: modelPyName,
+          model_args: JSON.stringify(args),
+          invest_interface: `Workbench ${WORKBENCH_VERSION}`,
+          session_id: sessionId,
+        }),
+        headers: { 'Content-Type': 'application/json' },
+      });
+    } catch (error) {
+      logger.warn('Failed to log model start');
+      logger.warn(error.stack);
+    }
+  }
+
+  function exit(status) {
+    try {
+      logger.debug('logging model exit');
+      fetch(`${HOSTNAME}:${process.env.PORT}/log_model_exit`, {
+        method: 'post',
+        body: JSON.stringify({
+          session_id: sessionId,
+          status: status,
+        }),
+        headers: { 'Content-Type': 'application/json' },
+      });
+    } catch (error) {
+      logger.warn('Failed to log model exit');
+      logger.warn(error.stack);
+    }
+  }
+
+  return {
+    start: start,
+    exit: exit,
+  };
+}

--- a/src/main/investUsageLogger.js
+++ b/src/main/investUsageLogger.js
@@ -1,59 +1,13 @@
 import crypto from 'crypto';
 
+import fetch from 'node-fetch';
+
 import { getLogger } from '../logger';
 import pkg from '../../package.json';
 
 const logger = getLogger(__filename.split('/').slice(-1)[0]);
 const WORKBENCH_VERSION = pkg.version;
 const HOSTNAME = 'http://localhost';
-
-
-// /** Send request to log invest model usage.
-//  *
-//  * @param {string} modelPyName - identifies the invest model's python module
-//  * @param {object} args - key: value pairs representing the model's args dict
-//  * @param {string} sessionId - a UUID version4 id to link start and exit rows.
-//  */
-// function logModelStart(modelPyName, args, sessionId) {
-//   try {
-//     logger.debug('logging model start');
-//     fetch(`${HOSTNAME}:${process.env.PORT}/log_model_start`, {
-//       method: 'post',
-//       body: JSON.stringify({
-//         model_pyname: modelPyName,
-//         model_args: JSON.stringify(args),
-//         invest_interface: `Workbench ${WORKBENCH_VERSION}`,
-//         session_id: sessionId,
-//       }),
-//       headers: { 'Content-Type': 'application/json' },
-//     });
-//   } catch (error) {
-//     logger.warn('Failed to log model start');
-//     logger.warn(error.stack);
-//   }
-// }
-
-// /** Send request to log invest model exit status.
-//  *
-//  * @param {string} sessionId - a UUID version4 id to link start and exit rows.
-//  * @param {string} status - exit status, typically the python traceback.
-//  */
-// function logModelExit(sessionId, status) {
-//   try {
-//     logger.debug('logging model exit');
-//     fetch(`${HOSTNAME}:${process.env.PORT}/log_model_exit`, {
-//       method: 'post',
-//       body: JSON.stringify({
-//         session_id: sessionId,
-//         status: status,
-//       }),
-//       headers: { 'Content-Type': 'application/json' },
-//     });
-//   } catch (error) {
-//     logger.warn('Failed to log model exit');
-//     logger.warn(error.stack);
-//   }
-// }
 
 export default function investUsageLogger() {
   const sessionId = crypto.randomUUID();

--- a/src/main/isDevMode.js
+++ b/src/main/isDevMode.js
@@ -1,0 +1,4 @@
+// defaultApp property is added by electron in devmode.
+// It means the app is running in the "default" electron app
+// as opposed to a purposely-built package, as in production.
+export default !!process.defaultApp;

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -25,12 +25,12 @@ import {
   setupInvestLogReaderHandler
 } from './setupInvestHandlers';
 import { ipcMainChannels } from './ipcMainChannels';
-import { getLogger } from '../logger';
 import { menuTemplate } from './menubar';
+import ELECTRON_DEV_MODE from './isDevMode';
+import { getLogger } from '../logger';
 import pkg from '../../package.json';
-
+console.log(ELECTRON_DEV_MODE)
 const logger = getLogger(__filename.split('/').slice(-1)[0]);
-const ELECTRON_DEV_MODE = !!process.defaultApp; // a property added by electron.
 process.env.PORT = '56789';
 
 // Keep a global reference of the window object, if you don't, the window will

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -1,5 +1,4 @@
 import path from 'path';
-import os from 'os';
 
 import {
   app,
@@ -29,7 +28,7 @@ import { menuTemplate } from './menubar';
 import ELECTRON_DEV_MODE from './isDevMode';
 import { getLogger } from '../logger';
 import pkg from '../../package.json';
-console.log(ELECTRON_DEV_MODE)
+
 const logger = getLogger(__filename.split('/').slice(-1)[0]);
 process.env.PORT = '56789';
 

--- a/src/main/setupInvestHandlers.js
+++ b/src/main/setupInvestHandlers.js
@@ -10,9 +10,11 @@ import sanitizeHtml from 'sanitize-html';
 
 import { getLogger } from '../logger';
 import { ipcMainChannels } from './ipcMainChannels';
+import pkg from '../../package.json';
 
 const logger = getLogger(__filename.split('/').slice(-1)[0]);
 
+const WORKBENCH_VERSION = pkg.version;
 // to translate to the invest CLI's verbosity flag:
 const LOGLEVELMAP = {
   DEBUG: '--debug',
@@ -145,7 +147,7 @@ export function setupInvestRunHandlers(investExe) {
               body: JSON.stringify({
                 model_pyname: pyModuleName,
                 model_args: JSON.stringify(args),
-                invest_interface: 'Workbench', // TODO: include wb version
+                invest_interface: `Workbench ${WORKBENCH_VERSION}`,
                 session_id: usageSessionId,
               }),
               headers: { 'Content-Type': 'application/json' },

--- a/src/main/setupInvestHandlers.js
+++ b/src/main/setupInvestHandlers.js
@@ -74,7 +74,7 @@ export function setupInvestRunHandlers(investExe) {
     event, modelRunName, pyModuleName, args, loggingLevel, jobID
   ) => {
     let investRun;
-    let investLogfile;
+    let investStarted = false;
     let investStdErr = '';
     const logPatterns = { ...LOG_PATTERNS };
     logPatterns['invest-log-primary'] = new RegExp(pyModuleName);
@@ -135,11 +135,11 @@ export function setupInvestRunHandlers(investExe) {
     // 2. parse the logfile path from stdout.
     // 3. log the model run for invest usage stats.
     const stdOutCallback = async (data) => {
-      if (!investLogfile) {
-        // TODO: this match is a janky way of making sure things only once
+      if (!investStarted) {
         if (`${data}`.match('Writing log messages to')) {
+          investStarted = true;
           runningJobs[jobID] = investRun.pid;
-          investLogfile = `${data}`.split(' ').pop().trim();
+          const investLogfile = `${data}`.split(' ').pop().trim();
           event.reply(`invest-logging-${jobID}`, investLogfile);
           if (!ELECTRON_DEV_MODE && !process.env.PUPPETEER) {
             usageLogger.start(pyModuleName, args);

--- a/src/main/setupInvestHandlers.js
+++ b/src/main/setupInvestHandlers.js
@@ -123,7 +123,7 @@ export function setupInvestRunHandlers(investExe) {
         detached: true, // counter-intuitive, but w/ true: invest terminates when this shell terminates
       });
     } else { // windows
-      investRun = spawn(investExe, cmdArgs, {
+      investRun = spawn(`"${investExe}"`, cmdArgs, {
         shell: true,
       });
     }
@@ -141,7 +141,7 @@ export function setupInvestRunHandlers(investExe) {
           runningJobs[jobID] = investRun.pid;
           investLogfile = `${data}`.split(' ').pop().trim();
           event.reply(`invest-logging-${jobID}`, investLogfile);
-          if (!ELECTRON_DEV_MODE) {
+          if (!ELECTRON_DEV_MODE && !process.env.PUPPETEER) {
             usageLogger.start(pyModuleName, args);
           }
         }
@@ -178,7 +178,7 @@ export function setupInvestRunHandlers(investExe) {
           if (e) { logger.error(e); }
         });
       });
-      if (!ELECTRON_DEV_MODE) {
+      if (!ELECTRON_DEV_MODE && !process.env.PUPPETEER) {
         usageLogger.exit(investStdErr);
       }
     });

--- a/src/main/setupInvestHandlers.js
+++ b/src/main/setupInvestHandlers.js
@@ -17,9 +17,9 @@ const logger = getLogger(__filename.split('/').slice(-1)[0]);
 // to translate to the invest CLI's verbosity flag:
 const LOGLEVELMAP = {
   DEBUG: '--debug',
-  INFO: '-vvv',
-  WARNING: '-vv',
-  ERROR: '-v',
+  INFO: '-vv',
+  WARNING: '-v',
+  ERROR: '',
 };
 const TEMP_DIR = path.join(app.getPath('userData'), 'tmp');
 const HOSTNAME = 'http://localhost';

--- a/src/renderer/sampledata_registry.json
+++ b/src/renderer/sampledata_registry.json
@@ -1,133 +1,133 @@
 {
   "Carbon Model": {
     "filename": "Carbon.zip",
-    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.1.post321%2Bgf8ee8ff7%2Fdata%2FCarbon.zip?generation=1632769268347436&alt=media",
+    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.1.post464%2Bgb05dea2e%2Fdata%2FCarbon.zip?generation=1634156068290888&alt=media",
     "filesize": "1900623"
   },
   "Coastal Blue Carbon": {
     "filename": "CoastalBlueCarbon.zip",
-    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.1.post321%2Bgf8ee8ff7%2Fdata%2FCoastalBlueCarbon.zip?generation=1632769268268001&alt=media",
+    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.1.post464%2Bgb05dea2e%2Fdata%2FCoastalBlueCarbon.zip?generation=1634156068110427&alt=media",
     "filesize": "79665"
   },
   "Coastal Vulnerability": {
     "filename": "CoastalVulnerability.zip",
-    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.1.post321%2Bgf8ee8ff7%2Fdata%2FCoastalVulnerability.zip?generation=1632769269197102&alt=media",
+    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.1.post464%2Bgb05dea2e%2Fdata%2FCoastalVulnerability.zip?generation=1634156069755688&alt=media",
     "filesize": "39930468",
     "labelSuffix": "(recommended to run model)"
   },
   "Crop Production": {
     "filename": "CropProduction.zip",
-    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.1.post321%2Bgf8ee8ff7%2Fdata%2FCropProduction.zip?generation=1632769269629576&alt=media",
+    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.1.post464%2Bgb05dea2e%2Fdata%2FCropProduction.zip?generation=1634156069976608&alt=media",
     "filesize": "58678907",
     "labelSuffix": "(required to run model)"
   },
   "DelineateIt: Watershed Delineation": {
     "filename": "DelineateIt.zip",
-    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.1.post321%2Bgf8ee8ff7%2Fdata%2FDelineateIt.zip?generation=1632769268357227&alt=media",
+    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.1.post464%2Bgb05dea2e%2Fdata%2FDelineateIt.zip?generation=1634156068073661&alt=media",
     "filesize": "529494"
   },
   "Finfish Aquaculture": {
     "filename": "Aquaculture.zip",
-    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.1.post321%2Bgf8ee8ff7%2Fdata%2FAquaculture.zip?generation=1632769268189527&alt=media",
+    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.1.post464%2Bgb05dea2e%2Fdata%2FAquaculture.zip?generation=1634156068013475&alt=media",
     "filesize": "34618"
   },
   "Fisheries": {
     "filename": "Fisheries.zip",
-    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.1.post321%2Bgf8ee8ff7%2Fdata%2FFisheries.zip?generation=1632769268279059&alt=media",
+    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.1.post464%2Bgb05dea2e%2Fdata%2FFisheries.zip?generation=1634156068015076&alt=media",
     "filesize": "274301"
   },
   "Forest Carbon Edge Effect Model": {
     "filename": "forest_carbon_edge_effect.zip",
-    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.1.post321%2Bgf8ee8ff7%2Fdata%2Fforest_carbon_edge_effect.zip?generation=1632769269366304&alt=media",
+    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.1.post464%2Bgb05dea2e%2Fdata%2Fforest_carbon_edge_effect.zip?generation=1634156069140291&alt=media",
     "filesize": "1036547",
     "labelSuffix": "(required to run model)"
   },
   "GLOBIO": {
     "filename": "globio.zip",
-    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.1.post321%2Bgf8ee8ff7%2Fdata%2Fglobio.zip?generation=1632769269659923&alt=media",
+    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.1.post464%2Bgb05dea2e%2Fdata%2Fglobio.zip?generation=1634156069581120&alt=media",
     "filesize": "2082836"
   },
   "Habitat Quality": {
     "filename": "HabitatQuality.zip",
-    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.1.post321%2Bgf8ee8ff7%2Fdata%2FHabitatQuality.zip?generation=1632769268587327&alt=media",
+    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.1.post464%2Bgb05dea2e%2Fdata%2FHabitatQuality.zip?generation=1634156068498232&alt=media",
     "filesize": "1739986"
   },
   "Habitat Risk Assessment": {
     "filename": "HabitatRiskAssess.zip",
-    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.1.post321%2Bgf8ee8ff7%2Fdata%2FHabitatRiskAssess.zip?generation=1632769268722499&alt=media",
+    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.1.post464%2Bgb05dea2e%2Fdata%2FHabitatRiskAssess.zip?generation=1634156068532547&alt=media",
     "filesize": "3268540"
   },
   "Hydropower Water Yield": {
     "filename": "Annual_Water_Yield.zip",
-    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.1.post321%2Bgf8ee8ff7%2Fdata%2FAnnual_Water_Yield.zip?generation=1632769268263898&alt=media",
+    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.1.post464%2Bgb05dea2e%2Fdata%2FAnnual_Water_Yield.zip?generation=1634156068255950&alt=media",
     "filesize": "244433"
   },
   "Nutrient Delivery Ratio Model (NDR)": {
     "filename": "NDR.zip",
-    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.1.post321%2Bgf8ee8ff7%2Fdata%2FNDR.zip?generation=1632769268758885&alt=media",
+    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.1.post464%2Bgb05dea2e%2Fdata%2FNDR.zip?generation=1634156068616013&alt=media",
     "filesize": "702024"
   },
   "Crop Pollination": {
     "filename": "pollination.zip",
-    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.1.post321%2Bgf8ee8ff7%2Fdata%2Fpollination.zip?generation=1632769269590458&alt=media",
+    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.1.post464%2Bgb05dea2e%2Fdata%2Fpollination.zip?generation=1634156069381364&alt=media",
     "filesize": "634514"
   },
   "Recreation Model": {
     "filename": "recreation.zip",
-    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.1.post321%2Bgf8ee8ff7%2Fdata%2Frecreation.zip?generation=1632769269752991&alt=media",
+    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.1.post464%2Bgb05dea2e%2Fdata%2Frecreation.zip?generation=1634156069681893&alt=media",
     "filesize": "3695258"
   },
   "RouteDEM": {
     "filename": "RouteDEM.zip",
-    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.1.post321%2Bgf8ee8ff7%2Fdata%2FRouteDEM.zip?generation=1632769268684181&alt=media",
+    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.1.post464%2Bgb05dea2e%2Fdata%2FRouteDEM.zip?generation=1634156068620603&alt=media",
     "filesize": "526336"
   },
   "Scenario Generator: Proximity Based": {
     "filename": "scenario_proximity.zip",
-    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.1.post321%2Bgf8ee8ff7%2Fdata%2Fscenario_proximity.zip?generation=1632769269720930&alt=media",
+    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.1.post464%2Bgb05dea2e%2Fdata%2Fscenario_proximity.zip?generation=1634156069597486&alt=media",
     "filesize": "927821"
   },
   "Unobstructed Views: Scenic Quality Provision": {
     "filename": "ScenicQuality.zip",
-    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.1.post321%2Bgf8ee8ff7%2Fdata%2FScenicQuality.zip?generation=1632769269722479&alt=media",
+    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.1.post464%2Bgb05dea2e%2Fdata%2FScenicQuality.zip?generation=1634156069974587&alt=media",
     "filesize": "25073475"
   },
   "Sediment Delivery Ratio Model (SDR)": {
     "filename": "SDR.zip",
-    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.1.post321%2Bgf8ee8ff7%2Fdata%2FSDR.zip?generation=1632769268744316&alt=media",
+    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.1.post464%2Bgb05dea2e%2Fdata%2FSDR.zip?generation=1634156068712185&alt=media",
     "filesize": "726317"
   },
   "Seasonal Water Yield": {
     "filename": "Seasonal_Water_Yield.zip",
-    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.1.post321%2Bgf8ee8ff7%2Fdata%2FSeasonal_Water_Yield.zip?generation=1632769269012796&alt=media",
+    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.1.post464%2Bgb05dea2e%2Fdata%2FSeasonal_Water_Yield.zip?generation=1634156068717842&alt=media",
     "filesize": "703708"
   },
   "Urban Cooling Model": {
     "filename": "UrbanCoolingModel.zip",
-    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.1.post321%2Bgf8ee8ff7%2Fdata%2FUrbanCoolingModel.zip?generation=1632769269005883&alt=media",
+    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.1.post464%2Bgb05dea2e%2Fdata%2FUrbanCoolingModel.zip?generation=1634156068951102&alt=media",
     "filesize": "1132530"
   },
   "Urban Flood Risk Mitigation": {
     "filename": "UrbanFloodMitigation.zip",
-    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.1.post321%2Bgf8ee8ff7%2Fdata%2FUrbanFloodMitigation.zip?generation=1632769268986544&alt=media",
+    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.1.post464%2Bgb05dea2e%2Fdata%2FUrbanFloodMitigation.zip?generation=1634156068869234&alt=media",
     "filesize": "187926"
   },
   "Wave Energy": {
     "filename": "WaveEnergy.zip",
-    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.1.post321%2Bgf8ee8ff7%2Fdata%2FWaveEnergy.zip?generation=1632769270459762&alt=media",
+    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.1.post464%2Bgb05dea2e%2Fdata%2FWaveEnergy.zip?generation=1634156070552533&alt=media",
     "filesize": "77718614",
     "labelSuffix": "(required to run model)"
   },
   "Wind Energy": {
     "filename": "WindEnergy.zip",
-    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.1.post321%2Bgf8ee8ff7%2Fdata%2FWindEnergy.zip?generation=1632769269418318&alt=media",
+    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.1.post464%2Bgb05dea2e%2Fdata%2FWindEnergy.zip?generation=1634156069613335&alt=media",
     "filesize": "5436801",
     "labelSuffix": "(required to run model)"
   },
   "Global DEM & Landmass Polygon": {
     "filename": "Base_Data.zip",
     "labelSuffix": "(required for Wind & Wave Energy)",
-    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.1.post321%2Bgf8ee8ff7%2Fdata%2FBase_Data.zip?generation=1632769270602491&alt=media",
+    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.1.post464%2Bgb05dea2e%2Fdata%2FBase_Data.zip?generation=1634156072254286&alt=media",
     "filesize": "151372182"
   }
 }

--- a/src/renderer/ui_config.js
+++ b/src/renderer/ui_config.js
@@ -342,6 +342,22 @@ const uiSpec = {
       alpha_m: isNotSufficient.bind(null, 'monthly_alpha')
     }
   },
+  stormwater: {
+    order: [
+      ['workspace_dir', 'results_suffix'],
+      [
+        'adjust_retention_ratios',
+        'aggregate_areas_path',
+        'biophysical_table',
+        'lulc_path',
+        'precipitation_path',
+        'replacement_cost',
+        'retention_radius',
+        'road_centerlines_path',
+        'soil_group_path',
+      ]
+    ]
+  },
   urban_cooling_model: {
     order: [
       ["workspace_dir", "results_suffix"],

--- a/tests/binary_tests/puppet.test.js
+++ b/tests/binary_tests/puppet.test.js
@@ -92,7 +92,6 @@ beforeAll(() => {
     }
   );
   ELECTRON_PROCESS.stderr.on('data', (data) => {
-    console.log('error from electron process spawn:');
     console.log(`${data}`);
   });
   const stdOutCallback = async (data) => {
@@ -104,7 +103,6 @@ beforeAll(() => {
           defaultViewport: null,
         });
       } catch (e) {
-        console.log('error connecting with puppeteer:');
         console.log(e);
       }
       ELECTRON_PROCESS.stdout.removeListener('data', stdOutCallback);
@@ -139,6 +137,8 @@ afterAll(async () => {
 
 test('Run a real invest model', async () => {
   const { findByText, findByLabelText, findByRole } = queries;
+  // On GHA MacOS, we seem to have to wait a long time for the browser
+  // to be ready. Maybe related to https://github.com/natcap/invest-workbench/issues/158
   await waitFor(() => {
     expect(BROWSER && BROWSER.isConnected()).toBeTruthy();
   }, { timeout: 60000 });

--- a/tests/binary_tests/puppet.test.js
+++ b/tests/binary_tests/puppet.test.js
@@ -92,6 +92,7 @@ beforeAll(() => {
     }
   );
   ELECTRON_PROCESS.stderr.on('data', (data) => {
+    console.log('error from electron process spawn:');
     console.log(`${data}`);
   });
   const stdOutCallback = async (data) => {
@@ -103,6 +104,7 @@ beforeAll(() => {
           defaultViewport: null,
         });
       } catch (e) {
+        console.log('error connecting with puppeteer:');
         console.log(e);
       }
       ELECTRON_PROCESS.stdout.removeListener('data', stdOutCallback);
@@ -139,7 +141,7 @@ test('Run a real invest model', async () => {
   const { findByText, findByLabelText, findByRole } = queries;
   await waitFor(() => {
     expect(BROWSER && BROWSER.isConnected()).toBeTruthy();
-  }, { timeout: 30000 });
+  }, { timeout: 60000 });
   // find the mainWindow's index.html, not the splashScreen's splash.html
   const target = await BROWSER.waitForTarget(
     (target) => target.url().endsWith('index.html')

--- a/tests/binary_tests/puppet.test.js
+++ b/tests/binary_tests/puppet.test.js
@@ -138,7 +138,7 @@ afterAll(async () => {
 test('Run a real invest model', async () => {
   const { findByText, findByLabelText, findByRole } = queries;
   await waitFor(() => {
-    expect(BROWSER.isConnected()).toBeTruthy();
+    expect(BROWSER && BROWSER.isConnected()).toBeTruthy();
   }, { timeout: 30000 });
   // find the mainWindow's index.html, not the splashScreen's splash.html
   const target = await BROWSER.waitForTarget(

--- a/tests/binary_tests/puppet.test.js
+++ b/tests/binary_tests/puppet.test.js
@@ -86,7 +86,10 @@ beforeAll(() => {
     `"${BINARY_PATH}"`,
     // these are chromium args
     [`--remote-debugging-port=${PORT}`],
-    { shell: true }
+    {
+      shell: true,
+      env: { ...process.env, PUPPETEER: true }
+    }
   );
   ELECTRON_PROCESS.stderr.on('data', (data) => {
     console.log(`${data}`);

--- a/tests/binary_tests/puppet.test.js
+++ b/tests/binary_tests/puppet.test.js
@@ -211,7 +211,7 @@ test('Run a real invest model', async () => {
   expect(await findByText(sidebar, 'Run Canceled'));
   expect(await findByText(sidebar, 'Open Workspace'));
   await page.screenshot({ path: `${SCREENSHOT_PREFIX}6-run-canceled.png` });
-}, 120000); // >2x the sum of all the max timeouts within this test
+}, 240000); // >2x the sum of all the max timeouts within this test
 
 // Test for duplicate application launch.
 // We have the binary path, so now let's launch a new subprocess with the same binary

--- a/tests/main/main.test.js
+++ b/tests/main/main.test.js
@@ -32,6 +32,7 @@ import {
 import findInvestBinaries from '../../src/main/findInvestBinaries';
 import extractZipInplace from '../../src/main/extractZipInplace';
 import { ipcMainChannels } from '../../src/main/ipcMainChannels';
+import investUsageLogger from '../../src/main/investUsageLogger';
 import { getInvestModelNames } from '../../src/renderer/server_requests';
 import App from '../../src/renderer/app';
 import {
@@ -280,5 +281,11 @@ describe('Integration tests for Download Sample Data Modal', () => {
       const value = await getSettingsValue('sampleDataDir');
       expect(value).toBe(existingValue);
     });
+  });
+});
+
+describe('investUsageLogger', () => {
+  test('sends requests with correct payload', () => {
+
   });
 });

--- a/tests/renderer/app.test.js
+++ b/tests/renderer/app.test.js
@@ -624,9 +624,11 @@ describe('InVEST subprocess testing', () => {
 
     // Only finalTraceback text should be rendered in a red alert
     const alert = await findByRole('alert');
-    expect(alert).toHaveTextContent(new RegExp(`^${finalTraceback}`));
-    expect(alert).not.toHaveTextContent(someStdErr);
-    expect(alert).toHaveClass('alert-danger');
+    await waitFor(() => {
+      expect(alert).toHaveTextContent(new RegExp(`^${finalTraceback}`));
+      expect(alert).not.toHaveTextContent(someStdErr);
+      expect(alert).toHaveClass('alert-danger');
+    });
     expect(await findByRole('button', { name: 'Open Workspace' }))
       .toBeEnabled();
 

--- a/tests/renderer/logtab.test.js
+++ b/tests/renderer/logtab.test.js
@@ -36,7 +36,8 @@ function makeLogFile(text) {
 }
 
 function cleanupLogFile(logfilePath) {
-  fs.unlink(logfilePath, () => {
+  fs.unlink(logfilePath, (err) => {
+    if (err) { throw err; }
     fs.rmdirSync(path.dirname(logfilePath));
   });
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1063,7 +1063,7 @@
     ajv "^6.12.0"
     ajv-keywords "^3.4.1"
 
-"@electron/get@^1.0.1":
+"@electron/get@^1.0.1", "@electron/get@^1.13.0":
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/@electron/get/-/get-1.13.0.tgz#95c6bcaff4f9a505ea46792424f451efea89228c"
   integrity sha512-+SjZhRuRo+STTO1Fdhzqnv9D2ZhjxXP6egsJ9kiO8dtP68cDx7dFCwWi64dlMQV7sWcfW1OYCW4wviEBzmRsfQ==
@@ -1789,9 +1789,9 @@
   integrity sha512-yxDeaQIAJlMav7fH5AQqPH1u8YIuhYJXYBzxaQ4PifsU0GDO38MSdmEDeRlIxrKbC6NbEaaEHDanWb+y30U8SQ==
 
 "@types/node@^14.6.2":
-  version "14.17.15"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.17.15.tgz#d5ebfb62a69074ebb85cbe0529ad917bb8f2bae8"
-  integrity sha512-D1sdW0EcSCmNdLKBGMYb38YsHUS6JcM7yQ6sLQ9KuZ35ck7LYCKE7kYFHOO59ayFOY3zobWVZxf4KXhYHcHYFA==
+  version "14.17.21"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.17.21.tgz#6359d8cf73481e312a43886fa50afc70ce5592c6"
+  integrity sha512-zv8ukKci1mrILYiQOwGSV4FpkZhyxQtuFWGya2GujWg+zVAeRQ4qbaMmWp9vb9889CFA8JECH7lkwCL6Ygg8kA==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"
@@ -3084,9 +3084,9 @@ core-js-pure@^3.16.0:
   integrity sha512-2VV7DlIbooyTI7Bh+yzOOWL9tGwLnQKHno7qATE+fqZzDKYr6llVjVQOzpD/QLZFgXDPb8T71pJokHEZHEYJhQ==
 
 core-js@^3.6.5:
-  version "3.17.2"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.17.2.tgz#f960eae710dc62c29cca93d5332e3660e289db10"
-  integrity sha512-XkbXqhcXeMHPRk2ItS+zQYliAMilea2euoMsnpRRdDad6b2VY6CQQcwz1K8AnWesfw4p165RzY0bTnr3UrbYiA==
+  version "3.18.2"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.18.2.tgz#63a551e8a29f305cd4123754846e65896619ba5b"
+  integrity sha512-zNhPOUoSgoizoSQFdX1MeZO16ORRb9FFQLts8gSYbZU5FcgXhp24iMWMxnOQo5uIaIG7/6FA/IqJPwev1o9ZXQ==
 
 core-util-is@1.0.2:
   version "1.0.2"
@@ -3582,12 +3582,12 @@ electron@^11.1.0:
     "@types/node" "^12.0.12"
     extract-zip "^1.0.3"
 
-electron@^13.1.4:
-  version "13.3.0"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-13.3.0.tgz#5f4f245723dd50fcd2c3d386a1d66fe748af404f"
-  integrity sha512-d/BvOLDjI4i7yf9tqCuLL2fFGA2TrM/D9PyRpua+rJolG0qrwp/FohP02L0m+44kmPpofIo4l3NPwLmzyKKimA==
+electron@^15.1.1:
+  version "15.1.1"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-15.1.1.tgz#cd3eaaaf62aa30c0f2d28ba28c5b62bd5ee2c325"
+  integrity sha512-ogVGNWL38KegiqAhUdgjWoKPOufTqDb+cNIqQF/WpVxgauNjzXEk/RNEk7qlw946B/g2dHpzpHeUhi+D/4EcIg==
   dependencies:
-    "@electron/get" "^1.0.1"
+    "@electron/get" "^1.13.0"
     "@types/node" "^14.6.2"
     extract-zip "^1.0.3"
 


### PR DESCRIPTION
This PR adds invest usage logging to the Workbench. It relies on changes in https://github.com/natcap/invest/pull/678

Logging is done by `natcap.invest.usage` via a `ui_server` endpoint. The workbench requests the logging when the model starts and exits. The solution here is not nearly as elegant as the context manager we use to do this in Qt, but that's just not an option with node & spawned subprocesses.

This is setup to only do the logging in production mode, and not during puppeteer tests.

Database entries look something like this now:
```
| model_name                       | invest_release           | invest_interface      | time                     | ip_address | bounding_box_union                                                                 | bounding_box_intersection                                                          | node_hash | system_full_platform_string | system_preferred_encoding | system_default_language | session_id                           |
+----------------------------------+--------------------------+-----------------------+--------------------------+------------+------------------------------------------------------------------------------------+------------------------------------------------------------------------------------+-----------+-----------------------------+---------------------------+-------------------------+--------------------------------------+
| natcap.invest.carbon             | 3.9.1.post451+gc2a32f316 | Workbench 0.1.0-alpha | 2021-10-07T19:18:15.017Z | NULL       | [-123.70489878706152, 44.249954424247804, -123.20882889655645, 44.762121780513645] | [-123.70489878706152, 44.249954424247804, -123.20882889655645, 44.762121780513645] | NULL      | Windows-10-10.0.19043-SP0   | cp1252                    | en_US                   | 394571e3-6950-4538-b0a3-8b336c51d0c3 |
| natcap.invest.carbon             | 3.9.1.post446+gfb9442c9e.d20211005 | Qt               | 2021-10-05T20:00:04.929Z | NULL       | [-123.70488835731115, 44.24994809617993, -123.20882373475214, 44.7621148918994] | [-123.70488835731115, 44.24994809617993, -123.20882373475214, 44.7621148918994] | NULL      | Windows-10-10.0.19043-SP0   | cp1252                    | en_US                   | bccb8767-1000-4fd8-8b5d-71d2e055d562 |
```

This PR also upgrades to electron v15 to get a version of node 14.x that includes `crypto.randomUUID`. No changes were needed to support the upgrade.

There's also a little bit of cleanup in `InvestTab` as I noticed a slightly simpler way to manage invest stderr data.