### PR TITLE
Task/123 disable devtools & inspect element in production

### DIFF
--- a/src/main/ipcMainChannels.js
+++ b/src/main/ipcMainChannels.js
@@ -5,6 +5,5 @@ export const ipcMainChannels = {
   INVEST_RUN: 'invest-run',
   INVEST_KILL: 'invest-kill',
   INVEST_READ_LOG: 'invest-read-log',
-  SHOW_CONTEXT_MENU: 'show-context-menu',
   IS_FIRST_RUN: 'is-first-run',
 };

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -1,5 +1,6 @@
 import path from 'path';
 
+// eslint-disable-next-line import/no-extraneous-dependencies
 import {
   app,
   BrowserWindow,
@@ -7,7 +8,7 @@ import {
   nativeTheme,
   Menu,
   ipcMain,
-} from 'electron'; // eslint-disable-line import/no-extraneous-dependencies
+} from 'electron';
 
 import {
   createPythonFlaskProcess,
@@ -24,7 +25,7 @@ import {
   setupInvestLogReaderHandler
 } from './setupInvestHandlers';
 import { ipcMainChannels } from './ipcMainChannels';
-import { menuTemplate } from './menubar';
+import menuTemplate from './menubar';
 import ELECTRON_DEV_MODE from './isDevMode';
 import { getLogger } from '../logger';
 import pkg from '../../package.json';

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -76,9 +76,6 @@ export const createWindow = async () => {
       contextIsolation: false,
       nodeIntegration: true,
       preload: path.join(__dirname, '..', 'preload.js'),
-      additionalArguments: [
-        ELECTRON_DEV_MODE ? '--dev' : 'packaged'
-      ],
       defaultEncoding: 'UTF-8',
     },
   });

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -56,7 +56,6 @@ export const createWindow = async () => {
   createPythonFlaskProcess(investExe);
   logger.info(`Running invest-workbench version ${pkg.version}`);
   setupDialogs();
-  setupContextMenu();
   setupCheckFirstRun();
 
   // always use light mode regardless of the OS/browser setting
@@ -120,6 +119,7 @@ export const createWindow = async () => {
   setupDownloadHandlers(mainWindow);
   setupInvestRunHandlers(investExe);
   setupInvestLogReaderHandler();
+  setupContextMenu(mainWindow);
 };
 
 export function removeIpcMainListeners() {

--- a/src/main/menubar.js
+++ b/src/main/menubar.js
@@ -1,10 +1,10 @@
-import { app, BrowserWindow } from 'electron';
+import { app, BrowserWindow } from 'electron'; // eslint-disable-line import/no-extraneous-dependencies
 
 import setupContextMenu from './setupContextMenu';
 
 const isMac = process.platform === 'darwin';
 
-function menuTemplate(parentWindow, isDevMode) {
+export default function menuTemplate(parentWindow, isDevMode) {
   // Much of this template comes straight from the docs
   // https://www.electronjs.org/docs/api/menu
   const template = [
@@ -147,5 +147,3 @@ function openReportWindow(parentWindow, isDevMode) {
     child.webContents.openDevTools();
   }
 }
-
-module.exports.menuTemplate = menuTemplate;

--- a/src/main/menubar.js
+++ b/src/main/menubar.js
@@ -1,4 +1,6 @@
-const { app, BrowserWindow } = require('electron');
+import { app, BrowserWindow } from 'electron';
+
+import setupContextMenu from './setupContextMenu';
 
 const isMac = process.platform === 'darwin';
 
@@ -117,6 +119,7 @@ function openAboutWindow(parentWindow, isDevMode) {
       minimumFontSize: 18,
     },
   });
+  setupContextMenu(child);
   child.setMenu(null);
   child.loadURL(`file://${__dirname}/../static/about.html`);
   if (isDevMode) {
@@ -137,6 +140,7 @@ function openReportWindow(parentWindow, isDevMode) {
       minimumFontSize: 18,
     },
   });
+  setupContextMenu(child);
   child.setMenu(null);
   child.loadURL(`file://${__dirname}/../static/report_a_problem.html`);
   if (isDevMode) {

--- a/src/main/menubar.js
+++ b/src/main/menubar.js
@@ -63,7 +63,6 @@ function menuTemplate(parentWindow, isDevMode) {
       submenu: [
         { role: 'reload' },
         { role: 'forcereload' },
-        { role: 'toggledevtools' },
         { type: 'separator' },
         { role: 'resetzoom' },
         { role: 'zoomin' },

--- a/src/main/setupContextMenu.js
+++ b/src/main/setupContextMenu.js
@@ -1,4 +1,4 @@
-import { Menu } from 'electron';
+import { Menu } from 'electron'; // eslint-disable-line import/no-extraneous-dependencies
 
 import ELECTRON_DEV_MODE from './isDevMode';
 

--- a/src/main/setupContextMenu.js
+++ b/src/main/setupContextMenu.js
@@ -1,25 +1,45 @@
-import {
-  BrowserWindow,
-  ipcMain,
-  Menu
-} from 'electron';
+import { Menu } from 'electron';
 
 import ELECTRON_DEV_MODE from './isDevMode';
-import { ipcMainChannels } from './ipcMainChannels';
 
-export default function setupContextMenu() {
-  ipcMain.on(ipcMainChannels.SHOW_CONTEXT_MENU, (event, rightClickPos) => {
+const selectionArray = [
+  { role: 'copy' },
+  { type: 'separator' },
+  { role: 'selectall' },
+];
+
+const inputArray = [
+  { role: 'undo' },
+  { role: 'redo' },
+  { type: 'separator' },
+  { role: 'cut' },
+  { role: 'copy' },
+  { role: 'paste' },
+  { type: 'separator' },
+  { role: 'selectall' },
+];
+
+export default function setupContextMenu(win) {
+  win.webContents.on('context-menu', (e, props) => {
     const template = [];
     if (ELECTRON_DEV_MODE) {
       template.push({
         label: 'Inspect Element',
         click: () => {
-          BrowserWindow.fromWebContents(event.sender)
-            .inspectElement(rightClickPos.x, rightClickPos.y);
+          win.inspectElement(props.x, props.y);
         }
       });
+      template.push({ type: 'separator' });
     }
-    const menu = Menu.buildFromTemplate(template);
-    menu.popup(BrowserWindow.fromWebContents(event.sender));
+    const { selectionText, isEditable } = props;
+    let menu;
+    if (isEditable) {
+      menu = Menu.buildFromTemplate(template.concat(inputArray));
+    } else if (selectionText && selectionText.trim() !== '') {
+      menu = Menu.buildFromTemplate(template.concat(selectionArray));
+    } else {
+      menu = Menu.buildFromTemplate(template);
+    }
+    menu.popup(win);
   });
 }

--- a/src/main/setupContextMenu.js
+++ b/src/main/setupContextMenu.js
@@ -4,19 +4,21 @@ import {
   Menu
 } from 'electron';
 
+import ELECTRON_DEV_MODE from './isDevMode';
 import { ipcMainChannels } from './ipcMainChannels';
 
 export default function setupContextMenu() {
   ipcMain.on(ipcMainChannels.SHOW_CONTEXT_MENU, (event, rightClickPos) => {
-    const template = [
-      {
+    const template = [];
+    if (ELECTRON_DEV_MODE) {
+      template.push({
         label: 'Inspect Element',
         click: () => {
           BrowserWindow.fromWebContents(event.sender)
             .inspectElement(rightClickPos.x, rightClickPos.y);
         }
-      },
-    ];
+      });
+    }
     const menu = Menu.buildFromTemplate(template);
     menu.popup(BrowserWindow.fromWebContents(event.sender));
   });

--- a/src/main/setupContextMenu.js
+++ b/src/main/setupContextMenu.js
@@ -19,8 +19,15 @@ const inputArray = [
   { role: 'selectall' },
 ];
 
+/** Setup listener for right-clicks on a given browser window.
+ *
+ * The content of the menu is constructed based on whether the target
+ * is an editable element or selected text. And whether we're in dev mode.
+ *
+ * @param {BrowserWindow} win - an instance of an electron BrowserWindow.
+ */
 export default function setupContextMenu(win) {
-  win.webContents.on('context-menu', (e, props) => {
+  win.webContents.on('context-menu', (event, props) => {
     const template = [];
     if (ELECTRON_DEV_MODE) {
       template.push({

--- a/src/preload.js
+++ b/src/preload.js
@@ -6,7 +6,6 @@ const { getLogger } = require('./logger');
 
 function preload() {
   window.Workbench = {
-    isDevMode: !!process.defaultApp,
     getLogger: getLogger,
   };
 }

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -8,14 +8,14 @@ import { ipcMainChannels } from '../main/ipcMainChannels';
 const logger = window.Workbench.getLogger(__filename.split('/').slice(-1)[0]);
 
 // Create a right-click menu
-// TODO: Not sure if Inspect Element should be available in production
-// very useful in dev though.
 let rightClickPosition = null;
-window.addEventListener('contextmenu', (e) => {
-  e.preventDefault();
-  rightClickPosition = { x: e.x, y: e.y };
-  ipcRenderer.send(ipcMainChannels.SHOW_CONTEXT_MENU, rightClickPosition);
-});
+if (window.Workbench.isDevMode) {
+  window.addEventListener('contextmenu', (e) => {
+    e.preventDefault();
+    rightClickPosition = { x: e.x, y: e.y };
+    ipcRenderer.send(ipcMainChannels.SHOW_CONTEXT_MENU, rightClickPosition);
+  });
+}
 
 function render(isFirstRun) {
   ReactDom.render(

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -7,14 +7,6 @@ import { ipcMainChannels } from '../main/ipcMainChannels';
 
 const logger = window.Workbench.getLogger(__filename.split('/').slice(-1)[0]);
 
-// Create a right-click menu
-let rightClickPosition = null;
-window.addEventListener('contextmenu', (e) => {
-  e.preventDefault();
-  rightClickPosition = { x: e.x, y: e.y };
-  ipcRenderer.send(ipcMainChannels.SHOW_CONTEXT_MENU, rightClickPosition);
-});
-
 function render(isFirstRun) {
   ReactDom.render(
     <App isFirstRun={isFirstRun} />,

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -9,13 +9,11 @@ const logger = window.Workbench.getLogger(__filename.split('/').slice(-1)[0]);
 
 // Create a right-click menu
 let rightClickPosition = null;
-if (window.Workbench.isDevMode) {
-  window.addEventListener('contextmenu', (e) => {
-    e.preventDefault();
-    rightClickPosition = { x: e.x, y: e.y };
-    ipcRenderer.send(ipcMainChannels.SHOW_CONTEXT_MENU, rightClickPosition);
-  });
-}
+window.addEventListener('contextmenu', (e) => {
+  e.preventDefault();
+  rightClickPosition = { x: e.x, y: e.y };
+  ipcRenderer.send(ipcMainChannels.SHOW_CONTEXT_MENU, rightClickPosition);
+});
 
 function render(isFirstRun) {
   ReactDom.render(

--- a/src/static/about.html
+++ b/src/static/about.html
@@ -136,6 +136,7 @@
     </p>
   </body>
   <script>
+    const { shell } = require('electron');
     const pkg = require('../../package.json');
 
     const node1 = document.getElementById('invest-version');

--- a/tests/main/main.test.js
+++ b/tests/main/main.test.js
@@ -184,7 +184,6 @@ describe('createWindow', () => {
       ipcMainChannels.INVEST_RUN,
       ipcMainChannels.INVEST_KILL,
       ipcMainChannels.INVEST_READ_LOG,
-      ipcMainChannels.SHOW_CONTEXT_MENU,
     ];
     createWindow();
     await waitFor(() => {


### PR DESCRIPTION
This PR fixes #123 by removing the option to "Inspect Element" from the context menu and to "toggle developer tools" from the View menu. These options are now available in Dev mode but not in production.

There are also additions to the right-lick context menu to offer some standard options depending on what was clicked (cut/copy/paste/select all, etc). And now we're using the electron `webContents.on('context-menu)` API instead of `window.addEventListener('contextmenu')`, so the whole thing is setup in the main process instead of the renderer.