### PR TITLE
Code signing for mac

### DIFF
--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 defaults:
   run:
-    shell: bash -l {0}
+    shell: bash -l -x {0}
 
 jobs:
   build-and-release:
@@ -62,12 +62,13 @@ jobs:
       if: github.event_name != 'pull_request' && matrix.os == 'macos-latest'
       shell: bash
       env:
-        P12_FILE_PATH: ~/Downloads/codesign_cert.p12
+        P12_FILE_PATH: ~/codesign_cert.p12
         KEYCHAIN_NAME: codesign_keychain
         KEYCHAIN_PASS: ${{ secrets.MAC_KEYCHAIN_PASS }}
         CERT_KEY_PASS: ${{ secrets.CODESIGN_CERT_KEY_PASS }}
 
       run: |
+
         gsutil cp gs://stanford_cert/20220510Expiry-macOSInstallerDistributionCert.p12 $P12_FILE_PATH
 
         ls ~/Downloads
@@ -87,9 +88,10 @@ jobs:
     - name: Code-signing setup for Windows
       if: github.event_name != 'pull_request' && matrix.os == 'windows-latest'
       env:
-        P12_FILE: 20220510Expiry-macOSInstallerDistributionCert.p12
+        P12_FILE_PATH: ~/20220510Expiry-macOSInstallerDistributionCert.p12
         CLOUDSDK_PYTHON: ${{env.pythonLocation}}\python.exe
       run: |
+
         gsutil cp gs://stanford_cert/$P12_FILE ~/$P12_FILE
 
         # all these variables are used by electron-builder

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -70,11 +70,12 @@ jobs:
       env:
         KEYCHAIN_NAME: codesign_keychain
         KEYCHAIN_PASS: ${{ secrets.MAC_KEYCHAIN_PASS }}
-        CERT_KEY_PASS: ${{ secrets.CODESIGN_CERT_KEY_PASS }}
+        CERT_PASS: ${{ secrets.MACOS_CODESIGN_CERT_PASS }}
+        CERT_FILE: 2025-01-16-Expiry-AppStore-App.p12
         BIN_TO_SIGN: dist/invest_*.dmg
       run: |
-        P12_FILE_NAME=codesign_cert.p12
-        gsutil cp gs://stanford_cert/2025-01-16-Expiry-AppStore-App.p12 ~/$P12_FILE_NAME
+
+        gsutil cp gs://stanford_cert/$CERT_FILE ~/$CERT_FILE
         ls ~/
 
         # create a new keychain (so that we can know what the password is)
@@ -89,12 +90,10 @@ jobs:
         # add the certificate to the keychain
         # -T option says that the codesign executable can access the keychain
         # for some reason this alone is not enough, also need the following step
-        security import ~/$P12_FILE_NAME -k $KEYCHAIN_NAME -P $CERT_KEY_PASS -T /usr/bin/codesign
+        security import ~/$CERT_FILE -k "$KEYCHAIN_NAME" -P "$CERT_PASS" -T /usr/bin/codesign
 
         # this is essential to avoid the UI password prompt
         security set-key-partition-list -S apple-tool:,apple: -s -k $KEYCHAIN_PASS $KEYCHAIN_NAME
-
-        security find-identity
 
         # sign the dmg using certificate that's looked up by unique identifier 'Stanford'
         codesign --timestamp --verbose --sign Stanford $BIN_TO_SIGN
@@ -106,27 +105,27 @@ jobs:
       if: github.event_name != 'pull_request' && matrix.os == 'windows-latest'
       env:
         CLOUDSDK_PYTHON: ${{env.pythonLocation}}\python.exe
+        CERT_FILE: Stanford-natcap-code-signing-cert-expires-2024-01-26.p12
       run: |
-        P12_FILE_NAME=codesign_cert.p12
-        gsutil cp gs://stanford_cert/2025-01-16-Expiry-AppStore-App.p12 ~/$P12_FILE_NAME
+        gsutil cp gs://stanford_cert/$CERT_FILE ~/$CERT_FILE
         ls ~/
         # figure out the path to signtool.exe
         SIGNTOOL=$(find 'C:\\Program Files (x86)\\Windows Kits\\10' -type f -name 'signtool.exe*' | head -n 1)
         echo $SIGNTOOL
         echo "SIGNTOOL=$SIGNTOOL" >> $GITHUB_ENV
 
-        # powershell.exe "& '$SIGNTOOL' sign /f '$HOME\$P12_FILE_NAME' /fd SHA256 /p '$CERT_KEY_PASS' /u 1.2.840.113635.100.4.9 '$BIN_TO_SIGN'"
+        # powershell.exe "& '$SIGNTOOL' sign /f '$HOME\$CERT_FILE' /fd SHA256 /p '$CERT_PASS' /u 1.2.840.113635.100.4.9 '$BIN_TO_SIGN'"
         # powershell.exe "& '$SIGNTOOL' timestamp /td SHA256 /tr http://timestamp.sectigo.com  '$BIN_TO_SIGN'"
 
     - name: Code signing part 2 (Windows)
       if: github.event_name != 'pull_request' && matrix.os == 'windows-latest'
       shell: pwsh
       env:
-        CERT_KEY_PASS: ${{ secrets.CODESIGN_CERT_KEY_PASS }}
+        CERT_PASS: ${{ secrets.WINDOWS_CODESIGN_CERT_PASS }}
         BIN_TO_SIGN: dist\invest_*.exe
-        P12_FILE_NAME: codesign_cert.p12
+        CERT_FILE: Stanford-natcap-code-signing-cert-expires-2024-01-26.p12
       run: |
-        & "$SIGNTOOL" sign /fd SHA256 /f "$HOME\$P12_FILE_NAME" /p "$CERT_KEY_PASS" $BIN_TO_SIGN
+        & "$SIGNTOOL" sign /fd SHA256 /f "$HOME\$CERT_FILE" /p "$CERT_PASS" $BIN_TO_SIGN
         & "$SIGNTOOL" timestamp /tr http://timestamp.sectigo.com /td SHA256 $BIN_TO_SIGN
 
 

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -73,8 +73,9 @@ jobs:
         bash ./scripts/setup_macos_keychain.sh 
 
         # these env variables tell electron-builder to do code signing
+        echo "CSC_IDENTITY_AUTO_DISCOVERY=false" >> $GITHUB_ENV
         echo "CSC_KEYCHAIN=$KEYCHAIN_NAME" >> $GITHUB_ENV
-        echo "CSC_NAME='Stanford University'" >> $GITHUB_ENV
+        echo "CSC_NAME='3rd Party Mac Developer Installer: Stanford University (CQRZ4E7K9U)'" >> $GITHUB_ENV
         echo "CSC_KEY_PASSWORD=${{ secrets.STANFORD_CERT_KEY_PASS }}" >> $GITHUB_ENV
 
     - name: Code-signing setup for Windows

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -75,7 +75,7 @@ jobs:
         # ls ~/Downloads
 
         # these env variables tell electron-builder to do code signing
-        echo "CSC_IDENTITY_AUTO_DISCOVERY=false" >> $GITHUB_ENV
+        # echo "CSC_IDENTITY_AUTO_DISCOVERY=false" >> $GITHUB_ENV
         echo "CSC_LINK=~/$P12_FILE_NAME" >> $GITHUB_ENV
         echo "CSC_KEY_PASSWORD=${{ secrets.CODESIGN_CERT_KEY_PASS }}" >> $GITHUB_ENV
 
@@ -85,7 +85,6 @@ jobs:
     - name: Code-signing setup for Windows
       if: github.event_name != 'pull_request' && matrix.os == 'windows-latest'
       env:
-        # P12_SOURCE_PATH: gs://stanford_cert//20220510Expiry-macOSInstallerDistributionCert.p12
         P12_FILE_NAME: codesign_cert.p12
         CLOUDSDK_PYTHON: ${{env.pythonLocation}}\python.exe
       run: |

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -116,8 +116,8 @@ jobs:
         echo $SIGNTOOL
         echo "SIGNTOOL=$SIGNTOOL" >> $GITHUB_ENV
 
-        powershell.exe "& $SIGNTOOL sign /fd SHA256 /f ~/$CERT_FILE /p $CERT_PASS $BIN_TO_SIGN"
-        powershell.exe "& $SIGNTOOL timestamp /tr http://timestamp.sectigo.com /td SHA256 '$BIN_TO_SIGN'"
+        powershell.exe "& '$SIGNTOOL' sign /fd SHA256 /f ~/$CERT_FILE /p $CERT_PASS $BIN_TO_SIGN"
+        powershell.exe "& '$SIGNTOOL' timestamp /tr http://timestamp.sectigo.com /td SHA256 '$BIN_TO_SIGN'"
 
     # - name: Code signing part 2 (Windows)
     #   if: github.event_name != 'pull_request' && matrix.os == 'windows-latest'

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -74,7 +74,7 @@ jobs:
         BIN_TO_SIGN: dist/invest_*.dmg
       run: |
         P12_FILE_NAME=codesign_cert.p12
-        gsutil cp gs://stanford_cert/20220510Expiry-macOSInstallerDistributionCert.p12 ~/$P12_FILE_NAME
+        gsutil cp gs://stanford_cert/2025-01-16-Expiry-AppStore-App.p12 ~/$P12_FILE_NAME
         ls ~/
 
         # create a new keychain (so that we can know what the password is)
@@ -108,7 +108,7 @@ jobs:
         CLOUDSDK_PYTHON: ${{env.pythonLocation}}\python.exe
       run: |
         P12_FILE_NAME=codesign_cert.p12
-        gsutil cp gs://stanford_cert/20220510Expiry-macOSInstallerDistributionCert.p12 ~/$P12_FILE_NAME
+        gsutil cp gs://stanford_cert/2025-01-16-Expiry-AppStore-App.p12 ~/$P12_FILE_NAME
         ls ~/
         # figure out the path to signtool.exe
         SIGNTOOL=$(find 'C:\\Program Files (x86)\\Windows Kits\\10' -type f -name 'signtool.exe*' | head -n 1)

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -94,8 +94,8 @@ jobs:
         # this is essential to avoid the UI password prompt
         security set-key-partition-list -S apple-tool:,apple: -s -k $KEYCHAIN_PASS $KEYCHAIN_NAME
 
-        # sign the dmg using certificate that's looked up by unique identifier 'Stanford Univeristy'
-        codesign --timestamp --verbose --sign 'Stanford University' $BIN_TO_SIGN
+        # sign the dmg using certificate that's looked up by unique identifier 'Stanford'
+        codesign --timestamp --verbose --sign 'Stanford' $BIN_TO_SIGN
 
         # relock the keychain (not sure if this is important?)
         security lock-keychain $KEYCHAIN_NAME
@@ -104,15 +104,21 @@ jobs:
       if: github.event_name != 'pull_request' && matrix.os == 'windows-latest'
       env:
         CLOUDSDK_PYTHON: ${{env.pythonLocation}}\python.exe
-        CERT_KEY_PASS: ${{ secrets.CODESIGN_CERT_KEY_PASS }}
-        BIN_TO_SIGN: dist\invest_*.exe
       run: |
         P12_FILE_NAME=codesign_cert.p12
         gsutil cp gs://stanford_cert/20220510Expiry-macOSInstallerDistributionCert.p12 ~/$P12_FILE_NAME
         ls ~/
 
-        pwsh -command ". 'SignTool sign /fd SHA256 /f "$HOME\$P12_FILE_NAME" /p $CERT_KEY_PASS $BIN_TO_SIGN'"
-        pwsh -command ". 'SignTool timestamp /tr http://timestamp.sectigo.com /td SHA256 $BIN_TO_SIGN'"
+    - name: Code signing part 2 (Windows)
+      if: github.event_name != 'pull_request' && matrix.os == 'windows-latest'
+      shell: pwsh
+      env:
+        CERT_KEY_PASS: ${{ secrets.CODESIGN_CERT_KEY_PASS }}
+        BIN_TO_SIGN: dist\invest_*.exe
+        P12_FILE_NAME: codesign_cert.p12
+      run: |
+        SignTool sign /fd SHA256 /f "$HOME\$P12_FILE_NAME" /p "$CERT_KEY_PASS" $BIN_TO_SIGN
+        SignTool timestamp /tr http://timestamp.sectigo.com /td SHA256 $BIN_TO_SIGN
 
 
     - name: Test electron app with puppeteer

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -60,15 +60,14 @@ jobs:
 
     - name: Code-signing setup for macOS
       if: github.event_name != 'pull_request' && matrix.os == 'macos-latest'
-      shell: bash
       env:
-        P12_FILE_PATH: ~/codesign_cert.p12
+        P12_FILE_NAME: codesign_cert.p12
         KEYCHAIN_NAME: codesign_keychain
         KEYCHAIN_PASS: ${{ secrets.MAC_KEYCHAIN_PASS }}
         CERT_KEY_PASS: ${{ secrets.CODESIGN_CERT_KEY_PASS }}
 
       run: |
-        gsutil cp gs://stanford_cert/20220510Expiry-macOSInstallerDistributionCert.p12 $P12_FILE_PATH
+        gsutil cp gs://stanford_cert/20220510Expiry-macOSInstallerDistributionCert.p12 ~/$P12_FILE_NAME
         ls ~/
 
         # bash ./scripts/setup_macos_keychain.sh
@@ -77,7 +76,7 @@ jobs:
 
         # these env variables tell electron-builder to do code signing
         echo "CSC_IDENTITY_AUTO_DISCOVERY=false" >> $GITHUB_ENV
-        echo "CSC_LINK=$P12_FILE_PATH" >> $GITHUB_ENV
+        echo "CSC_LINK=~/$P12_FILE_NAME" >> $GITHUB_ENV
         echo "CSC_KEY_PASSWORD=${{ secrets.CODESIGN_CERT_KEY_PASS }}" >> $GITHUB_ENV
 
         # echo "CSC_KEYCHAIN=$KEYCHAIN_NAME" >> $GITHUB_ENV
@@ -87,14 +86,14 @@ jobs:
       if: github.event_name != 'pull_request' && matrix.os == 'windows-latest'
       env:
         # P12_SOURCE_PATH: gs://stanford_cert//20220510Expiry-macOSInstallerDistributionCert.p12
-        P12_FILE_PATH: ~/codesign_cert.p12
+        P12_FILE_NAME: codesign_cert.p12
         CLOUDSDK_PYTHON: ${{env.pythonLocation}}\python.exe
       run: |
 
-        gsutil cp gs://stanford_cert/20220510Expiry-macOSInstallerDistributionCert.p12 $P12_FILE_PATH
+        gsutil cp gs://stanford_cert/20220510Expiry-macOSInstallerDistributionCert.p12 ~/$P12_FILE_NAME
 
         # all these variables are used by electron-builder
-        echo "CSC_LINK=$P12_FILE_PATH" >> $GITHUB_ENV
+        echo "CSC_LINK=~/$P12_FILE_NAME" >> $GITHUB_ENV
         echo "CSC_KEY_PASSWORD=${{ secrets.CODESIGN_CERT_KEY_PASS }}" >> $GITHUB_ENV
         echo "CSC_IDENTITY_AUTO_DISCOVERY=false" >> $GITHUB_ENV
 

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -58,46 +58,12 @@ jobs:
         version: '281.0.0'
         service_account_key: ${{ secrets.GOOGLE_SERVICE_ACC_KEY }}
 
-    - name: Code-signing setup
-      if: github.event_name != 'pull_request'
-      env:
-        CLOUDSDK_PYTHON: ${{env.pythonLocation}}\python.exe
-      run: |
-        echo "CSC_IDENTITY_AUTO_DISCOVERY=false" >> $GITHUB_ENV
-        echo "P12_FILE_NAME=codesign_cert.p12" >> $GITHUB_ENV
-        gsutil cp gs://stanford_cert/20220510Expiry-macOSInstallerDistributionCert.p12 ~/$P12_FILE_NAME
-        ls ~/
-
-
-    # - name: Set up keychain for macOS
-    #   if: github.event_name != 'pull_request' && matrix.os == 'macos-latest'
-    #   run: bash ./scripts/setup_macos_keychain.sh
-
-    # - name: Code-signing setup for Windows
-    #   if: github.event_name != 'pull_request' && matrix.os == 'windows-latest'
-    #   env:
-    #     P12_FILE_NAME: codesign_cert.p12
-    #     CLOUDSDK_PYTHON: ${{env.pythonLocation}}\python.exe
-    #   run: |
-    #     gsutil cp gs://stanford_cert/20220510Expiry-macOSInstallerDistributionCert.p12 ~/$P12_FILE_NAME
-    #     echo "CSC_IDENTITY_AUTO_DISCOVERY=false" >> $GITHUB_ENV
-
     - name: Run electron-builder
       env:
         GH_TOKEN: env.GITHUB_TOKEN
         DEBUG: electron-builder
-      run: |
-        ls ~/
-        yarn run dist
-
-    - name: Code signing (Windows)
-      if: github.event_name != 'pull_request' && matrix.os == 'windows-latest'
-      env:
-        CERT_KEY_PASS: ${{ secrets.CODESIGN_CERT_KEY_PASS }}
-        BIN_TO_SIGN: dist\invest_*.exe
-      run: |
-        powershell.exe "& SignTool sign /fd SHA256 /f ~\$P12_FILE_NAME /p $CERT_KEY_PASS $BIN_TO_SIGN"
-        powershell.exe "& SignTool timestamp /tr http://timestamp.sectigo.com /td SHA256 $BIN_TO_SIGN"
+        CSC_IDENTITY_AUTO_DISCOVERY: false  # disable electron-builder code signing
+      run: yarn run dist
 
     - name: Code signing (MacOS)
       if: github.event_name != 'pull_request' && matrix.os == 'macos-latest'
@@ -105,8 +71,12 @@ jobs:
         KEYCHAIN_NAME: codesign_keychain
         KEYCHAIN_PASS: ${{ secrets.MAC_KEYCHAIN_PASS }}
         CERT_KEY_PASS: ${{ secrets.CODESIGN_CERT_KEY_PASS }}
-        BIN_TO_SIGN: dist\invest_*.dmg
+        BIN_TO_SIGN: dist/invest_*.dmg
       run: |
+        P12_FILE_NAME=codesign_cert.p12
+        gsutil cp gs://stanford_cert/20220510Expiry-macOSInstallerDistributionCert.p12 ~/$P12_FILE_NAME
+        ls ~/
+
         # create a new keychain (so that we can know what the password is)
         security create-keychain -p $KEYCHAIN_PASS $KEYCHAIN_NAME
 
@@ -119,7 +89,7 @@ jobs:
         # add the certificate to the keychain
         # -T option says that the codesign executable can access the keychain
         # for some reason this alone is not enough, also need the following step
-        security import $(BUILD_DIR)/$(P12_FILE) -k $KEYCHAIN_NAME -P $CERT_KEY_PASS -T /usr/bin/codesign
+        security import ~/$P12_FILE_NAME -k $KEYCHAIN_NAME -P $CERT_KEY_PASS -T /usr/bin/codesign
 
         # this is essential to avoid the UI password prompt
         security set-key-partition-list -S apple-tool:,apple: -s -k $KEYCHAIN_PASS $KEYCHAIN_NAME
@@ -129,6 +99,20 @@ jobs:
 
         # relock the keychain (not sure if this is important?)
         security lock-keychain $KEYCHAIN_NAME
+
+    - name: Code signing (Windows)
+      if: github.event_name != 'pull_request' && matrix.os == 'windows-latest'
+      env:
+        CLOUDSDK_PYTHON: ${{env.pythonLocation}}\python.exe
+        CERT_KEY_PASS: ${{ secrets.CODESIGN_CERT_KEY_PASS }}
+        BIN_TO_SIGN: dist\invest_*.exe
+      run: |
+        P12_FILE_NAME=codesign_cert.p12
+        gsutil cp gs://stanford_cert/20220510Expiry-macOSInstallerDistributionCert.p12 ~/$P12_FILE_NAME
+        ls ~/
+
+        pwsh -command ". 'SignTool sign /fd SHA256 /f "$HOME\$P12_FILE_NAME" /p $CERT_KEY_PASS $BIN_TO_SIGN'"
+        pwsh -command ". 'SignTool timestamp /tr http://timestamp.sectigo.com /td SHA256 $BIN_TO_SIGN'"
 
 
     - name: Test electron app with puppeteer

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -94,6 +94,8 @@ jobs:
         # this is essential to avoid the UI password prompt
         security set-key-partition-list -S apple-tool:,apple: -s -k $KEYCHAIN_PASS $KEYCHAIN_NAME
 
+        security find-identity
+
         # sign the dmg using certificate that's looked up by unique identifier 'Stanford'
         codesign --timestamp --verbose --sign 'Stanford' $BIN_TO_SIGN
 

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -116,8 +116,13 @@ jobs:
         echo $SIGNTOOL
         echo "SIGNTOOL=$SIGNTOOL" >> $GITHUB_ENV
 
-        powershell.exe "& '$SIGNTOOL' sign /fd SHA256 /f ~/$CERT_FILE /p $CERT_PASS $BIN_TO_SIGN"
-        powershell.exe "& '$SIGNTOOL' timestamp /tr http://timestamp.sectigo.com /td SHA256 '$BIN_TO_SIGN'"
+        echo "$SIGNTOOL"
+        "$SIGNTOOL"
+        "$SIGNTOOL" sign -fd SHA256 -f ~/$CERT_FILE -p $CERT_PASS $BIN_TO_SIGN
+        "$SIGNTOOL" sign /fd SHA256 /f ~/$CERT_FILE /p $CERT_PASS $BIN_TO_SIGN
+
+        # powershell.exe "& '$SIGNTOOL' sign /fd SHA256 /f ~/$CERT_FILE /p $CERT_PASS $BIN_TO_SIGN"
+        # powershell.exe "& '$SIGNTOOL' timestamp /tr http://timestamp.sectigo.com /td SHA256 '$BIN_TO_SIGN'"
 
     # - name: Code signing part 2 (Windows)
     #   if: github.event_name != 'pull_request' && matrix.os == 'windows-latest'

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -76,7 +76,7 @@ jobs:
         echo "CSC_IDENTITY_AUTO_DISCOVERY=false" >> $GITHUB_ENV
         echo "CSC_KEYCHAIN=$KEYCHAIN_NAME" >> $GITHUB_ENV
         echo "CSC_NAME='3rd Party Mac Developer Installer: Stanford University (CQRZ4E7K9U)'" >> $GITHUB_ENV
-        echo "CSC_KEY_PASSWORD=${{ secrets.STANFORD_CERT_KEY_PASS }}" >> $GITHUB_ENV
+        echo "CSC_KEY_PASSWORD=${{ secrets.CODESIGN_CERT_KEY_PASS }}" >> $GITHUB_ENV
 
     - name: Code-signing setup for Windows
       if: github.event_name != 'pull_request' && matrix.os == 'windows-latest'

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 defaults:
   run:
-    shell: bash -l -x {0}
+    shell: bash -l {0}
 
 jobs:
   build-and-release:
@@ -65,6 +65,7 @@ jobs:
         CSC_IDENTITY_AUTO_DISCOVERY: false  # disable electron-builder code signing
       run: yarn run dist
 
+    # do code signing ourselves because it's easier than with electron-builder
     - name: Code signing (MacOS)
       if: github.event_name != 'pull_request' && matrix.os == 'macos-latest'
       env:
@@ -74,10 +75,7 @@ jobs:
         CERT_FILE: 2025-01-16-Expiry-AppStore-App.p12
         BIN_TO_SIGN: dist/invest_*.dmg
       run: |
-
         gsutil cp gs://stanford_cert/$CERT_FILE ~/$CERT_FILE
-        ls ~/
-
         # create a new keychain (so that we can know what the password is)
         security create-keychain -p $KEYCHAIN_PASS $KEYCHAIN_NAME
 
@@ -113,23 +111,9 @@ jobs:
 
         # figure out the path to signtool.exe
         SIGNTOOL=$(find 'C:\\Program Files (x86)\\Windows Kits\\10' -type f -name 'signtool.exe*' | head -n 1)
-        echo $SIGNTOOL
-        echo "SIGNTOOL=$SIGNTOOL" >> $GITHUB_ENV
 
         "$SIGNTOOL" sign -fd SHA256 -f ~/$CERT_FILE -p $CERT_PASS $BIN_TO_SIGN
         "$SIGNTOOL" timestamp -tr http://timestamp.sectigo.com -td SHA256 $BIN_TO_SIGN
-
-    # - name: Code signing part 2 (Windows)
-    #   if: github.event_name != 'pull_request' && matrix.os == 'windows-latest'
-    #   shell: pwsh
-    #   env:
-    #     CERT_PASS: ${{ secrets.WINDOWS_CODESIGN_CERT_PASS }}
-    #     BIN_TO_SIGN: dist\invest_*.exe
-    #     CERT_FILE: Stanford-natcap-code-signing-cert-expires-2024-01-26.p12
-    #   run: |
-    #     & "$SIGNTOOL" sign /fd SHA256 /f "$HOME\$CERT_FILE" /p "$CERT_PASS" $BIN_TO_SIGN
-    #     & "$SIGNTOOL" timestamp /tr http://timestamp.sectigo.com /td SHA256 $BIN_TO_SIGN
-
 
     - name: Test electron app with puppeteer
       run: yarn run test-electron-app

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -70,7 +70,11 @@ jobs:
       run: |
         gsutil cp gs://stanford_cert/20220510Expiry-macOSInstallerDistributionCert.p12 $P12_FILE_PATH
 
-        bash ./scripts/setup_macos_keychain.sh 
+        ls ~/Downloads
+
+        # bash ./scripts/setup_macos_keychain.sh
+
+        # ls ~/Downloads
 
         # these env variables tell electron-builder to do code signing
         echo "CSC_IDENTITY_AUTO_DISCOVERY=false" >> $GITHUB_ENV
@@ -97,7 +101,10 @@ jobs:
       env:
         GH_TOKEN: env.GITHUB_TOKEN
         DEBUG: electron-builder
-      run: yarn run dist
+      run: |
+        ls ~/Downloads
+
+        yarn run dist
 
     - name: Test electron app with puppeteer
       run: yarn run test-electron-app

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -119,8 +119,8 @@ jobs:
         BIN_TO_SIGN: dist\invest_*.exe
         P12_FILE_NAME: codesign_cert.p12
       run: |
-        SignTool sign /fd SHA256 /f "$HOME\$P12_FILE_NAME" /p "$CERT_KEY_PASS" $BIN_TO_SIGN
-        SignTool timestamp /tr http://timestamp.sectigo.com /td SHA256 $BIN_TO_SIGN
+        signtool sign /fd SHA256 /f "$HOME\$P12_FILE_NAME" /p "$CERT_KEY_PASS" $BIN_TO_SIGN
+        signtool timestamp /tr http://timestamp.sectigo.com /td SHA256 $BIN_TO_SIGN
 
 
     - name: Test electron app with puppeteer

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -68,10 +68,8 @@ jobs:
         CERT_KEY_PASS: ${{ secrets.CODESIGN_CERT_KEY_PASS }}
 
       run: |
-
         gsutil cp gs://stanford_cert/20220510Expiry-macOSInstallerDistributionCert.p12 $P12_FILE_PATH
-
-        ls ~/Downloads
+        ls ~/
 
         # bash ./scripts/setup_macos_keychain.sh
 
@@ -88,14 +86,15 @@ jobs:
     - name: Code-signing setup for Windows
       if: github.event_name != 'pull_request' && matrix.os == 'windows-latest'
       env:
-        P12_FILE_PATH: ~/20220510Expiry-macOSInstallerDistributionCert.p12
+        # P12_SOURCE_PATH: gs://stanford_cert//20220510Expiry-macOSInstallerDistributionCert.p12
+        P12_FILE_PATH: ~/codesign_cert.p12
         CLOUDSDK_PYTHON: ${{env.pythonLocation}}\python.exe
       run: |
 
-        gsutil cp gs://stanford_cert/$P12_FILE ~/$P12_FILE
+        gsutil cp gs://stanford_cert/20220510Expiry-macOSInstallerDistributionCert.p12 $P12_FILE_PATH
 
         # all these variables are used by electron-builder
-        echo "CSC_LINK=~/$P12_FILE" >> $GITHUB_ENV
+        echo "CSC_LINK=$P12_FILE_PATH" >> $GITHUB_ENV
         echo "CSC_KEY_PASSWORD=${{ secrets.CODESIGN_CERT_KEY_PASS }}" >> $GITHUB_ENV
         echo "CSC_IDENTITY_AUTO_DISCOVERY=false" >> $GITHUB_ENV
 
@@ -104,7 +103,7 @@ jobs:
         GH_TOKEN: env.GITHUB_TOKEN
         DEBUG: electron-builder
       run: |
-        ls ~/Downloads
+        ls ~/
 
         yarn run dist
 

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -74,9 +74,11 @@ jobs:
 
         # these env variables tell electron-builder to do code signing
         echo "CSC_IDENTITY_AUTO_DISCOVERY=false" >> $GITHUB_ENV
-        echo "CSC_KEYCHAIN=$KEYCHAIN_NAME" >> $GITHUB_ENV
-        echo "CSC_NAME='3rd Party Mac Developer Installer: Stanford University (CQRZ4E7K9U)'" >> $GITHUB_ENV
+        echo "CSC_LINK=$P12_FILE_PATH" >> $GITHUB_ENV
         echo "CSC_KEY_PASSWORD=${{ secrets.CODESIGN_CERT_KEY_PASS }}" >> $GITHUB_ENV
+
+        # echo "CSC_KEYCHAIN=$KEYCHAIN_NAME" >> $GITHUB_ENV
+        # echo "CSC_NAME='3rd Party Mac Developer Installer: Stanford University (CQRZ4E7K9U)'" >> $GITHUB_ENV
 
     - name: Code-signing setup for Windows
       if: github.event_name != 'pull_request' && matrix.os == 'windows-latest'
@@ -88,7 +90,7 @@ jobs:
 
         # all these variables are used by electron-builder
         echo "CSC_LINK=~/$P12_FILE" >> $GITHUB_ENV
-        echo "CSC_KEY_PASSWORD=${{ secrets.STANFORD_CERT_KEY_PASS }}" >> $GITHUB_ENV
+        echo "CSC_KEY_PASSWORD=${{ secrets.CODESIGN_CERT_KEY_PASS }}" >> $GITHUB_ENV
         echo "CSC_IDENTITY_AUTO_DISCOVERY=false" >> $GITHUB_ENV
 
     - name: Run electron-builder

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -58,43 +58,29 @@ jobs:
         version: '281.0.0'
         service_account_key: ${{ secrets.GOOGLE_SERVICE_ACC_KEY }}
 
-    - name: Code-signing setup for macOS
-      if: github.event_name != 'pull_request' && matrix.os == 'macos-latest'
+    - name: Code-signing setup
+      if: github.event_name != 'pull_request'
       env:
-        P12_FILE_NAME: codesign_cert.p12
-        KEYCHAIN_NAME: codesign_keychain
-        KEYCHAIN_PASS: ${{ secrets.MAC_KEYCHAIN_PASS }}
-        CERT_KEY_PASS: ${{ secrets.CODESIGN_CERT_KEY_PASS }}
-
+        CLOUDSDK_PYTHON: ${{env.pythonLocation}}\python.exe
       run: |
+        echo "CSC_IDENTITY_AUTO_DISCOVERY=false" >> $GITHUB_ENV
+        echo "P12_FILE_NAME=codesign_cert.p12" >> $GITHUB_ENV
         gsutil cp gs://stanford_cert/20220510Expiry-macOSInstallerDistributionCert.p12 ~/$P12_FILE_NAME
         ls ~/
 
-        # bash ./scripts/setup_macos_keychain.sh
 
-        # ls ~/Downloads
+    # - name: Set up keychain for macOS
+    #   if: github.event_name != 'pull_request' && matrix.os == 'macos-latest'
+    #   run: bash ./scripts/setup_macos_keychain.sh
 
-        # these env variables tell electron-builder to do code signing
-        # echo "CSC_IDENTITY_AUTO_DISCOVERY=false" >> $GITHUB_ENV
-        echo "CSC_LINK=~/$P12_FILE_NAME" >> $GITHUB_ENV
-        echo "CSC_KEY_PASSWORD=${{ secrets.CODESIGN_CERT_KEY_PASS }}" >> $GITHUB_ENV
-
-        # echo "CSC_KEYCHAIN=$KEYCHAIN_NAME" >> $GITHUB_ENV
-        # echo "CSC_NAME='3rd Party Mac Developer Installer: Stanford University (CQRZ4E7K9U)'" >> $GITHUB_ENV
-
-    - name: Code-signing setup for Windows
-      if: github.event_name != 'pull_request' && matrix.os == 'windows-latest'
-      env:
-        P12_FILE_NAME: codesign_cert.p12
-        CLOUDSDK_PYTHON: ${{env.pythonLocation}}\python.exe
-      run: |
-
-        gsutil cp gs://stanford_cert/20220510Expiry-macOSInstallerDistributionCert.p12 ~/$P12_FILE_NAME
-
-        # all these variables are used by electron-builder
-        echo "CSC_LINK=~/$P12_FILE_NAME" >> $GITHUB_ENV
-        echo "CSC_KEY_PASSWORD=${{ secrets.CODESIGN_CERT_KEY_PASS }}" >> $GITHUB_ENV
-        echo "CSC_IDENTITY_AUTO_DISCOVERY=false" >> $GITHUB_ENV
+    # - name: Code-signing setup for Windows
+    #   if: github.event_name != 'pull_request' && matrix.os == 'windows-latest'
+    #   env:
+    #     P12_FILE_NAME: codesign_cert.p12
+    #     CLOUDSDK_PYTHON: ${{env.pythonLocation}}\python.exe
+    #   run: |
+    #     gsutil cp gs://stanford_cert/20220510Expiry-macOSInstallerDistributionCert.p12 ~/$P12_FILE_NAME
+    #     echo "CSC_IDENTITY_AUTO_DISCOVERY=false" >> $GITHUB_ENV
 
     - name: Run electron-builder
       env:
@@ -102,8 +88,48 @@ jobs:
         DEBUG: electron-builder
       run: |
         ls ~/
-
         yarn run dist
+
+    - name: Code signing (Windows)
+      if: github.event_name != 'pull_request' && matrix.os == 'windows-latest'
+      env:
+        CERT_KEY_PASS: ${{ secrets.CODESIGN_CERT_KEY_PASS }}
+        BIN_TO_SIGN: dist\invest_*.exe
+      run: |
+        powershell.exe "& SignTool sign /fd SHA256 /f ~\$P12_FILE_NAME /p $CERT_KEY_PASS $BIN_TO_SIGN"
+        powershell.exe "& SignTool timestamp /tr http://timestamp.sectigo.com /td SHA256 $BIN_TO_SIGN"
+
+    - name: Code signing (MacOS)
+      if: github.event_name != 'pull_request' && matrix.os == 'macos-latest'
+      env:
+        KEYCHAIN_NAME: codesign_keychain
+        KEYCHAIN_PASS: ${{ secrets.MAC_KEYCHAIN_PASS }}
+        CERT_KEY_PASS: ${{ secrets.CODESIGN_CERT_KEY_PASS }}
+        BIN_TO_SIGN: dist\invest_*.dmg
+      run: |
+        # create a new keychain (so that we can know what the password is)
+        security create-keychain -p $KEYCHAIN_PASS $KEYCHAIN_NAME
+
+        # add the keychain to the search list so it can be found
+        security list-keychains -s $KEYCHAIN_NAME
+
+        # unlock the keychain so we can import to it (stays unlocked 5 minutes by default)
+        security unlock-keychain -p $KEYCHAIN_PASS $KEYCHAIN_NAME
+
+        # add the certificate to the keychain
+        # -T option says that the codesign executable can access the keychain
+        # for some reason this alone is not enough, also need the following step
+        security import $(BUILD_DIR)/$(P12_FILE) -k $KEYCHAIN_NAME -P $CERT_KEY_PASS -T /usr/bin/codesign
+
+        # this is essential to avoid the UI password prompt
+        security set-key-partition-list -S apple-tool:,apple: -s -k $KEYCHAIN_PASS $KEYCHAIN_NAME
+
+        # sign the dmg using certificate that's looked up by unique identifier 'Stanford Univeristy'
+        codesign --timestamp --verbose --sign 'Stanford University' $BIN_TO_SIGN
+
+        # relock the keychain (not sure if this is important?)
+        security lock-keychain $KEYCHAIN_NAME
+
 
     - name: Test electron app with puppeteer
       run: yarn run test-electron-app

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -94,13 +94,14 @@ jobs:
         # this is essential to avoid the UI password prompt
         security set-key-partition-list -S apple-tool:,apple: -s -k $KEYCHAIN_PASS $KEYCHAIN_NAME
 
+        echo "find identity:"
         security find-identity
 
-        # sign the dmg using certificate that's looked up by unique identifier 'Stanford'
-        codesign --timestamp --verbose --sign 'Stanford' $BIN_TO_SIGN
+        # # sign the dmg using certificate that's looked up by unique identifier 'Stanford'
+        # codesign --timestamp --verbose --sign 'Stanford' $BIN_TO_SIGN
 
-        # relock the keychain (not sure if this is important?)
-        security lock-keychain $KEYCHAIN_NAME
+        # # relock the keychain (not sure if this is important?)
+        # security lock-keychain $KEYCHAIN_NAME
 
     - name: Code signing (Windows)
       if: github.event_name != 'pull_request' && matrix.os == 'windows-latest'
@@ -119,8 +120,8 @@ jobs:
         BIN_TO_SIGN: dist\invest_*.exe
         P12_FILE_NAME: codesign_cert.p12
       run: |
-        signtool sign /fd SHA256 /f "$HOME\$P12_FILE_NAME" /p "$CERT_KEY_PASS" $BIN_TO_SIGN
-        signtool timestamp /tr http://timestamp.sectigo.com /td SHA256 $BIN_TO_SIGN
+        signtool.exe sign /fd SHA256 /f "$HOME\$P12_FILE_NAME" /p "$CERT_KEY_PASS" $BIN_TO_SIGN
+        signtool.exe timestamp /tr http://timestamp.sectigo.com /td SHA256 $BIN_TO_SIGN
 
 
     - name: Test electron app with puppeteer

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -94,14 +94,13 @@ jobs:
         # this is essential to avoid the UI password prompt
         security set-key-partition-list -S apple-tool:,apple: -s -k $KEYCHAIN_PASS $KEYCHAIN_NAME
 
-        echo "find identity:"
         security find-identity
 
-        # # sign the dmg using certificate that's looked up by unique identifier 'Stanford'
-        # codesign --timestamp --verbose --sign 'Stanford' $BIN_TO_SIGN
+        # sign the dmg using certificate that's looked up by unique identifier 'Stanford'
+        codesign --timestamp --verbose --sign Stanford $BIN_TO_SIGN
 
-        # # relock the keychain (not sure if this is important?)
-        # security lock-keychain $KEYCHAIN_NAME
+        # relock the keychain (not sure if this is important?)
+        security lock-keychain $KEYCHAIN_NAME
 
     - name: Code signing (Windows)
       if: github.event_name != 'pull_request' && matrix.os == 'windows-latest'
@@ -112,9 +111,12 @@ jobs:
         gsutil cp gs://stanford_cert/20220510Expiry-macOSInstallerDistributionCert.p12 ~/$P12_FILE_NAME
         ls ~/
         # figure out the path to signtool.exe
-        SIGNTOOL_PATH=$(find 'C:\\Program Files (x86)\\Windows Kits\\10' -type f -name 'signtool.exe*' | head -n 1)
-        echo $SIGNTOOL_PATH
-        echo "SIGNTOOL_PATH=$SIGNTOOL_PATH" >> $GITHUB_ENV
+        SIGNTOOL=$(find 'C:\\Program Files (x86)\\Windows Kits\\10' -type f -name 'signtool.exe*' | head -n 1)
+        echo $SIGNTOOL
+        echo "SIGNTOOL=$SIGNTOOL" >> $GITHUB_ENV
+
+        # powershell.exe "& '$SIGNTOOL' sign /f '$HOME\$P12_FILE_NAME' /fd SHA256 /p '$CERT_KEY_PASS' /u 1.2.840.113635.100.4.9 '$BIN_TO_SIGN'"
+        # powershell.exe "& '$SIGNTOOL' timestamp /td SHA256 /tr http://timestamp.sectigo.com  '$BIN_TO_SIGN'"
 
     - name: Code signing part 2 (Windows)
       if: github.event_name != 'pull_request' && matrix.os == 'windows-latest'
@@ -124,8 +126,8 @@ jobs:
         BIN_TO_SIGN: dist\invest_*.exe
         P12_FILE_NAME: codesign_cert.p12
       run: |
-        $SIGNTOOL_PATH sign /fd SHA256 /f "$HOME\$P12_FILE_NAME" /p "$CERT_KEY_PASS" $BIN_TO_SIGN
-        $SIGNTOOL_PATH timestamp /tr http://timestamp.sectigo.com /td SHA256 $BIN_TO_SIGN
+        & "$SIGNTOOL" sign /fd SHA256 /f "$HOME\$P12_FILE_NAME" /p "$CERT_KEY_PASS" $BIN_TO_SIGN
+        & "$SIGNTOOL" timestamp /tr http://timestamp.sectigo.com /td SHA256 $BIN_TO_SIGN
 
 
     - name: Test electron app with puppeteer

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -106,27 +106,29 @@ jobs:
       env:
         CLOUDSDK_PYTHON: ${{env.pythonLocation}}\python.exe
         CERT_FILE: Stanford-natcap-code-signing-cert-expires-2024-01-26.p12
+        CERT_PASS: ${{ secrets.WINDOWS_CODESIGN_CERT_PASS }}
+        BIN_TO_SIGN: dist\invest_*.exe
       run: |
         gsutil cp gs://stanford_cert/$CERT_FILE ~/$CERT_FILE
-        ls ~/
+
         # figure out the path to signtool.exe
         SIGNTOOL=$(find 'C:\\Program Files (x86)\\Windows Kits\\10' -type f -name 'signtool.exe*' | head -n 1)
         echo $SIGNTOOL
         echo "SIGNTOOL=$SIGNTOOL" >> $GITHUB_ENV
 
-        # powershell.exe "& '$SIGNTOOL' sign /f '$HOME\$CERT_FILE' /fd SHA256 /p '$CERT_PASS' /u 1.2.840.113635.100.4.9 '$BIN_TO_SIGN'"
-        # powershell.exe "& '$SIGNTOOL' timestamp /td SHA256 /tr http://timestamp.sectigo.com  '$BIN_TO_SIGN'"
+        powershell.exe "& $SIGNTOOL sign /fd SHA256 /f ~/$CERT_FILE /p $CERT_PASS $BIN_TO_SIGN"
+        powershell.exe "& $SIGNTOOL timestamp /tr http://timestamp.sectigo.com /td SHA256 '$BIN_TO_SIGN'"
 
-    - name: Code signing part 2 (Windows)
-      if: github.event_name != 'pull_request' && matrix.os == 'windows-latest'
-      shell: pwsh
-      env:
-        CERT_PASS: ${{ secrets.WINDOWS_CODESIGN_CERT_PASS }}
-        BIN_TO_SIGN: dist\invest_*.exe
-        CERT_FILE: Stanford-natcap-code-signing-cert-expires-2024-01-26.p12
-      run: |
-        & "$SIGNTOOL" sign /fd SHA256 /f "$HOME\$CERT_FILE" /p "$CERT_PASS" $BIN_TO_SIGN
-        & "$SIGNTOOL" timestamp /tr http://timestamp.sectigo.com /td SHA256 $BIN_TO_SIGN
+    # - name: Code signing part 2 (Windows)
+    #   if: github.event_name != 'pull_request' && matrix.os == 'windows-latest'
+    #   shell: pwsh
+    #   env:
+    #     CERT_PASS: ${{ secrets.WINDOWS_CODESIGN_CERT_PASS }}
+    #     BIN_TO_SIGN: dist\invest_*.exe
+    #     CERT_FILE: Stanford-natcap-code-signing-cert-expires-2024-01-26.p12
+    #   run: |
+    #     & "$SIGNTOOL" sign /fd SHA256 /f "$HOME\$CERT_FILE" /p "$CERT_PASS" $BIN_TO_SIGN
+    #     & "$SIGNTOOL" timestamp /tr http://timestamp.sectigo.com /td SHA256 $BIN_TO_SIGN
 
 
     - name: Test electron app with puppeteer

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -116,13 +116,8 @@ jobs:
         echo $SIGNTOOL
         echo "SIGNTOOL=$SIGNTOOL" >> $GITHUB_ENV
 
-        echo "$SIGNTOOL"
-        "$SIGNTOOL"
         "$SIGNTOOL" sign -fd SHA256 -f ~/$CERT_FILE -p $CERT_PASS $BIN_TO_SIGN
-        "$SIGNTOOL" sign /fd SHA256 /f ~/$CERT_FILE /p $CERT_PASS $BIN_TO_SIGN
-
-        # powershell.exe "& '$SIGNTOOL' sign /fd SHA256 /f ~/$CERT_FILE /p $CERT_PASS $BIN_TO_SIGN"
-        # powershell.exe "& '$SIGNTOOL' timestamp /tr http://timestamp.sectigo.com /td SHA256 '$BIN_TO_SIGN'"
+        "$SIGNTOOL" timestamp -tr http://timestamp.sectigo.com -td SHA256 $BIN_TO_SIGN
 
     # - name: Code signing part 2 (Windows)
     #   if: github.event_name != 'pull_request' && matrix.os == 'windows-latest'

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -111,6 +111,10 @@ jobs:
         P12_FILE_NAME=codesign_cert.p12
         gsutil cp gs://stanford_cert/20220510Expiry-macOSInstallerDistributionCert.p12 ~/$P12_FILE_NAME
         ls ~/
+        # figure out the path to signtool.exe
+        SIGNTOOL_PATH=$(find 'C:\\Program Files (x86)\\Windows Kits\\10' -type f -name 'signtool.exe*' | head -n 1)
+        echo $SIGNTOOL_PATH
+        echo "SIGNTOOL_PATH=$SIGNTOOL_PATH" >> $GITHUB_ENV
 
     - name: Code signing part 2 (Windows)
       if: github.event_name != 'pull_request' && matrix.os == 'windows-latest'
@@ -120,8 +124,8 @@ jobs:
         BIN_TO_SIGN: dist\invest_*.exe
         P12_FILE_NAME: codesign_cert.p12
       run: |
-        signtool.exe sign /fd SHA256 /f "$HOME\$P12_FILE_NAME" /p "$CERT_KEY_PASS" $BIN_TO_SIGN
-        signtool.exe timestamp /tr http://timestamp.sectigo.com /td SHA256 $BIN_TO_SIGN
+        $SIGNTOOL_PATH sign /fd SHA256 /f "$HOME\$P12_FILE_NAME" /p "$CERT_KEY_PASS" $BIN_TO_SIGN
+        $SIGNTOOL_PATH timestamp /tr http://timestamp.sectigo.com /td SHA256 $BIN_TO_SIGN
 
 
     - name: Test electron app with puppeteer

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -62,13 +62,13 @@ jobs:
       if: github.event_name != 'pull_request' && matrix.os == 'macos-latest'
       shell: bash
       env:
-        P12_FILE_PATH: ~/Downloads/stanford_cert.p12
+        P12_FILE_PATH: ~/Downloads/codesign_cert.p12
         KEYCHAIN_NAME: codesign_keychain
         KEYCHAIN_PASS: ${{ secrets.MAC_KEYCHAIN_PASS }}
-        CERT_KEY_PASS: ${{ secrets.STANFORD_CERT_KEY_PASS }}
+        CERT_KEY_PASS: ${{ secrets.CODESIGN_CERT_KEY_PASS }}
 
       run: |
-        gsutil cp gs://stanford_cert/Stanford-natcap-code-signing-cert-expires-2024-01-26.p12 $P12_FILE_PATH 
+        gsutil cp gs://stanford_cert/20220510Expiry-macOSInstallerDistributionCert.p12 $P12_FILE_PATH
 
         bash ./scripts/setup_macos_keychain.sh 
 
@@ -80,7 +80,7 @@ jobs:
     - name: Code-signing setup for Windows
       if: github.event_name != 'pull_request' && matrix.os == 'windows-latest'
       env:
-        P12_FILE: Stanford-natcap-code-signing-cert-expires-2024-01-26.p12
+        P12_FILE: 20220510Expiry-macOSInstallerDistributionCert.p12
         CLOUDSDK_PYTHON: ${{env.pythonLocation}}\python.exe
       run: |
         gsutil cp gs://stanford_cert/$P12_FILE ~/$P12_FILE

--- a/electron-builder-config.js
+++ b/electron-builder-config.js
@@ -51,6 +51,7 @@ const config = {
     'build/**/*',
     'node_modules/**/*',
   ],
+  forceCodeSigning: true,
 };
 
 module.exports = config;

--- a/electron-builder-config.js
+++ b/electron-builder-config.js
@@ -51,7 +51,6 @@ const config = {
     'build/**/*',
     'node_modules/**/*',
   ],
-  forceCodeSigning: true,
 };
 
 module.exports = config;


### PR DESCRIPTION
Fixes #28.

Note that code signing doesn't run in PRs, so be sure to check the GHA run on my branch instead: https://github.com/emlys/invest-workbench/tree/task/codesigning

* Use the new Apple Developer ID Application certificate for mac signing
* Use the same old certificate for windows signing
* Sign as a separate step outside of electron-builder, because it was too hard to configure.