### PR TITLE
Task/121 model list order

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "invest": {
     "bucket": "releases.naturalcapitalproject.org",
     "fork": "natcap",
-    "version": "3.9.1.post531+g2159bd07",
+    "version": "3.9.2.post470+g11795c5c",
     "target": {
       "macos": "mac_invest_binaries.zip",
       "windows": "windows_invest_binaries.zip"

--- a/src/renderer/app.jsx
+++ b/src/renderer/app.jsx
@@ -40,7 +40,7 @@ export default class App extends React.Component {
       activeTab: 'home',
       openNavIDs: [],
       openJobs: {},
-      investList: {},
+      investList: null,
       recentJobs: [],
       investSettings: null,
       showDownloadModal: false,
@@ -342,12 +342,16 @@ export default class App extends React.Component {
             onDragOver={dragOverHandlerNone}
           >
             <TabPane eventKey="home" title="Home">
-              <HomeTab
-                investList={investList}
-                openInvestModel={this.openInvestModel}
-                recentJobs={recentJobs}
-                batchUpdateArgs={this.batchUpdateArgs}
-              />
+              {(investList)
+                ? (
+                  <HomeTab
+                    investList={investList}
+                    openInvestModel={this.openInvestModel}
+                    recentJobs={recentJobs}
+                    batchUpdateArgs={this.batchUpdateArgs}
+                  />
+                )
+                : <div />}
             </TabPane>
             {investTabPanes}
           </TabContent>

--- a/src/renderer/components/HomeTab/index.jsx
+++ b/src/renderer/components/HomeTab/index.jsx
@@ -20,7 +20,26 @@ const logger = window.Workbench.getLogger(__filename.split('/').slice(-2).join('
 export default class HomeTab extends React.PureComponent {
   constructor(props) {
     super(props);
+    this.state = {
+      sortedModels: []
+    };
     this.handleClick = this.handleClick.bind(this);
+  }
+
+  componentDidMount() {
+    // sort the model list alphabetically, by the model title,
+    // and with special placement of CBC Preprocessor before CBC model.
+    const sortedModels = Object.keys(this.props.investList).sort();
+    const cbcpElement = 'Coastal Blue Carbon Preprocessor';
+    const cbcIdx = sortedModels.indexOf('Coastal Blue Carbon');
+    const cbcpIdx = sortedModels.indexOf(cbcpElement);
+    if (cbcIdx > -1 && cbcpIdx > -1) {
+      sortedModels.splice(cbcpIdx, 1); // remove it
+      sortedModels.splice(cbcIdx, 0, cbcpElement); // insert it
+    }
+    this.setState({
+      sortedModels: sortedModels
+    });
   }
 
   handleClick(event) {
@@ -35,17 +54,10 @@ export default class HomeTab extends React.PureComponent {
   }
 
   render() {
-    const { investList, recentJobs } = this.props;
+    const { recentJobs } = this.props;
+    const { sortedModels } = this.state;
     // A button in a table row for each model
     const investButtons = [];
-    const sortedModels = Object.keys(investList).sort();
-    try {
-      const cbcpElement = 'Coastal Blue Carbon Preprocessor';
-      const cbcIdx = sortedModels.indexOf('Coastal Blue Carbon');
-      const cbcpIdx = sortedModels.indexOf(cbcpElement);
-      sortedModels.splice(cbcpIdx, 1); // remove it
-      sortedModels.splice(cbcIdx, 0, cbcpElement); // insert it
-    } catch { } // If this ever doesn't work, it's okay;
     sortedModels.forEach((model) => {
       investButtons.push(
         <tr key={model}>

--- a/src/renderer/components/HomeTab/index.jsx
+++ b/src/renderer/components/HomeTab/index.jsx
@@ -71,7 +71,7 @@ export default class HomeTab extends React.PureComponent {
 
     return (
       <Row>
-        <Col md={6}>
+        <Col md={6} className="invest-list-container">
           <ListGroup className="invest-list-group">
             {investButtons}
           </ListGroup>

--- a/src/renderer/components/HomeTab/index.jsx
+++ b/src/renderer/components/HomeTab/index.jsx
@@ -38,7 +38,15 @@ export default class HomeTab extends React.PureComponent {
     const { investList, recentJobs } = this.props;
     // A button in a table row for each model
     const investButtons = [];
-    Object.keys(investList).sort().forEach((model) => {
+    const sortedModels = Object.keys(investList).sort();
+    try {
+      const cbcpElement = 'Coastal Blue Carbon Preprocessor';
+      const cbcIdx = sortedModels.indexOf('Coastal Blue Carbon');
+      const cbcpIdx = sortedModels.indexOf(cbcpElement);
+      sortedModels.splice(cbcpIdx, 1); // remove it
+      sortedModels.splice(cbcIdx, 0, cbcpElement); // insert it
+    } catch { } // If this ever doesn't work, it's okay;
+    sortedModels.forEach((model) => {
       investButtons.push(
         <tr key={model}>
           <td>

--- a/src/renderer/components/HomeTab/index.jsx
+++ b/src/renderer/components/HomeTab/index.jsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import Button from 'react-bootstrap/Button';
-import Table from 'react-bootstrap/Table';
+import ListGroup from 'react-bootstrap/ListGroup';
 import Card from 'react-bootstrap/Card';
 import Container from 'react-bootstrap/Container';
 import Col from 'react-bootstrap/Col';
@@ -42,8 +41,7 @@ export default class HomeTab extends React.PureComponent {
     });
   }
 
-  handleClick(event) {
-    const { value } = event.target;
+  handleClick(value) {
     const { investList, openInvestModel } = this.props;
     const modelRunName = investList[value].model_name;
     const job = new InvestJob({
@@ -60,31 +58,23 @@ export default class HomeTab extends React.PureComponent {
     const investButtons = [];
     sortedModels.forEach((model) => {
       investButtons.push(
-        <tr key={model}>
-          <td>
-            <Button
-              className="invest-button"
-              block
-              size="lg"
-              value={model}
-              onClick={this.handleClick}
-              variant="link"
-            >
-              {model}
-            </Button>
-          </td>
-        </tr>
+        <ListGroup.Item
+          key={model}
+          className="invest-button"
+          action
+          onClick={() => this.handleClick(model)}
+        >
+          {model}
+        </ListGroup.Item>
       );
     });
 
     return (
       <Row>
-        <Col md={5} className="invest-list-table">
-          <Table size="sm">
-            <tbody>
-              {investButtons}
-            </tbody>
-          </Table>
+        <Col md={6}>
+          <ListGroup className="invest-list-group">
+            {investButtons}
+          </ListGroup>
         </Col>
         <Col className="recent-job-card-col">
           <RecentInvestJobs

--- a/src/renderer/components/HomeTab/index.jsx
+++ b/src/renderer/components/HomeTab/index.jsx
@@ -38,7 +38,7 @@ export default class HomeTab extends React.PureComponent {
     const { investList, recentJobs } = this.props;
     // A button in a table row for each model
     const investButtons = [];
-    Object.keys(investList).forEach((model) => {
+    Object.keys(investList).sort().forEach((model) => {
       investButtons.push(
         <tr key={model}>
           <td>

--- a/src/renderer/sampledata_registry.json
+++ b/src/renderer/sampledata_registry.json
@@ -1,133 +1,133 @@
 {
   "Carbon Model": {
     "filename": "Carbon.zip",
-    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.1.post531%2Bg2159bd07%2Fdata%2FCarbon.zip?generation=1635279437672028&alt=media",
+    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.2.post470%2Bg11795c5c%2Fdata%2FCarbon.zip?generation=1635965587110810&alt=media",
     "filesize": "1900623"
   },
   "Coastal Blue Carbon": {
     "filename": "CoastalBlueCarbon.zip",
-    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.1.post531%2Bg2159bd07%2Fdata%2FCoastalBlueCarbon.zip?generation=1635279437677078&alt=media",
+    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.2.post470%2Bg11795c5c%2Fdata%2FCoastalBlueCarbon.zip?generation=1635965587053769&alt=media",
     "filesize": "79665"
   },
   "Coastal Vulnerability": {
     "filename": "CoastalVulnerability.zip",
-    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.1.post531%2Bg2159bd07%2Fdata%2FCoastalVulnerability.zip?generation=1635279439299267&alt=media",
+    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.2.post470%2Bg11795c5c%2Fdata%2FCoastalVulnerability.zip?generation=1635965588038981&alt=media",
     "filesize": "39930468",
     "labelSuffix": "(recommended to run model)"
   },
   "Crop Production": {
     "filename": "CropProduction.zip",
-    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.1.post531%2Bg2159bd07%2Fdata%2FCropProduction.zip?generation=1635279439487033&alt=media",
+    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.2.post470%2Bg11795c5c%2Fdata%2FCropProduction.zip?generation=1635965588297856&alt=media",
     "filesize": "58678907",
     "labelSuffix": "(required to run model)"
   },
   "DelineateIt: Watershed Delineation": {
     "filename": "DelineateIt.zip",
-    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.1.post531%2Bg2159bd07%2Fdata%2FDelineateIt.zip?generation=1635279437541968&alt=media",
+    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.2.post470%2Bg11795c5c%2Fdata%2FDelineateIt.zip?generation=1635965587023778&alt=media",
     "filesize": "529494"
   },
   "Finfish Aquaculture": {
     "filename": "Aquaculture.zip",
-    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.1.post531%2Bg2159bd07%2Fdata%2FAquaculture.zip?generation=1635279437531777&alt=media",
+    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.2.post470%2Bg11795c5c%2Fdata%2FAquaculture.zip?generation=1635965587012033&alt=media",
     "filesize": "34618"
   },
   "Fisheries": {
     "filename": "Fisheries.zip",
-    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.1.post531%2Bg2159bd07%2Fdata%2FFisheries.zip?generation=1635279437525339&alt=media",
+    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.2.post470%2Bg11795c5c%2Fdata%2FFisheries.zip?generation=1635965587037005&alt=media",
     "filesize": "274301"
   },
   "Forest Carbon Edge Effect Model": {
     "filename": "forest_carbon_edge_effect.zip",
-    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.1.post531%2Bg2159bd07%2Fdata%2Fforest_carbon_edge_effect.zip?generation=1635279438804075&alt=media",
+    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.2.post470%2Bg11795c5c%2Fdata%2Fforest_carbon_edge_effect.zip?generation=1635965588027032&alt=media",
     "filesize": "1036547",
     "labelSuffix": "(required to run model)"
   },
   "GLOBIO": {
     "filename": "globio.zip",
-    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.1.post531%2Bg2159bd07%2Fdata%2Fglobio.zip?generation=1635279438618768&alt=media",
+    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.2.post470%2Bg11795c5c%2Fdata%2Fglobio.zip?generation=1635965588202087&alt=media",
     "filesize": "2082836"
   },
   "Habitat Quality": {
     "filename": "HabitatQuality.zip",
-    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.1.post531%2Bg2159bd07%2Fdata%2FHabitatQuality.zip?generation=1635279437875573&alt=media",
+    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.2.post470%2Bg11795c5c%2Fdata%2FHabitatQuality.zip?generation=1635965587484614&alt=media",
     "filesize": "1739986"
   },
   "Habitat Risk Assessment": {
     "filename": "HabitatRiskAssess.zip",
-    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.1.post531%2Bg2159bd07%2Fdata%2FHabitatRiskAssess.zip?generation=1635279438103871&alt=media",
+    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.2.post470%2Bg11795c5c%2Fdata%2FHabitatRiskAssess.zip?generation=1635965587643866&alt=media",
     "filesize": "3268540"
   },
   "Hydropower Water Yield": {
     "filename": "Annual_Water_Yield.zip",
-    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.1.post531%2Bg2159bd07%2Fdata%2FAnnual_Water_Yield.zip?generation=1635279437626679&alt=media",
+    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.2.post470%2Bg11795c5c%2Fdata%2FAnnual_Water_Yield.zip?generation=1635965587079883&alt=media",
     "filesize": "244430"
   },
   "Nutrient Delivery Ratio Model (NDR)": {
     "filename": "NDR.zip",
-    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.1.post531%2Bg2159bd07%2Fdata%2FNDR.zip?generation=1635279437923854&alt=media",
+    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.2.post470%2Bg11795c5c%2Fdata%2FNDR.zip?generation=1635965587464653&alt=media",
     "filesize": "702024"
   },
   "Crop Pollination": {
     "filename": "pollination.zip",
-    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.1.post531%2Bg2159bd07%2Fdata%2Fpollination.zip?generation=1635279438718709&alt=media",
+    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.2.post470%2Bg11795c5c%2Fdata%2Fpollination.zip?generation=1635965588164112&alt=media",
     "filesize": "634514"
   },
   "Recreation Model": {
     "filename": "recreation.zip",
-    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.1.post531%2Bg2159bd07%2Fdata%2Frecreation.zip?generation=1635279439073783&alt=media",
+    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.2.post470%2Bg11795c5c%2Fdata%2Frecreation.zip?generation=1635965588513541&alt=media",
     "filesize": "3695258"
   },
   "RouteDEM": {
     "filename": "RouteDEM.zip",
-    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.1.post531%2Bg2159bd07%2Fdata%2FRouteDEM.zip?generation=1635279438114918&alt=media",
+    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.2.post470%2Bg11795c5c%2Fdata%2FRouteDEM.zip?generation=1635965587530052&alt=media",
     "filesize": "526336"
   },
   "Scenario Generator: Proximity Based": {
     "filename": "scenario_proximity.zip",
-    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.1.post531%2Bg2159bd07%2Fdata%2Fscenario_proximity.zip?generation=1635279439081676&alt=media",
+    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.2.post470%2Bg11795c5c%2Fdata%2Fscenario_proximity.zip?generation=1635965588485015&alt=media",
     "filesize": "927821"
   },
   "Unobstructed Views: Scenic Quality Provision": {
     "filename": "ScenicQuality.zip",
-    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.1.post531%2Bg2159bd07%2Fdata%2FScenicQuality.zip?generation=1635279439507152&alt=media",
+    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.2.post470%2Bg11795c5c%2Fdata%2FScenicQuality.zip?generation=1635965588492647&alt=media",
     "filesize": "25073475"
   },
   "Sediment Delivery Ratio Model (SDR)": {
     "filename": "SDR.zip",
-    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.1.post531%2Bg2159bd07%2Fdata%2FSDR.zip?generation=1635279438114229&alt=media",
+    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.2.post470%2Bg11795c5c%2Fdata%2FSDR.zip?generation=1635965587556100&alt=media",
     "filesize": "726317"
   },
   "Seasonal Water Yield": {
     "filename": "Seasonal_Water_Yield.zip",
-    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.1.post531%2Bg2159bd07%2Fdata%2FSeasonal_Water_Yield.zip?generation=1635279438183126&alt=media",
+    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.2.post470%2Bg11795c5c%2Fdata%2FSeasonal_Water_Yield.zip?generation=1635965587636398&alt=media",
     "filesize": "703708"
   },
   "Urban Cooling Model": {
     "filename": "UrbanCoolingModel.zip",
-    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.1.post531%2Bg2159bd07%2Fdata%2FUrbanCoolingModel.zip?generation=1635279438403959&alt=media",
+    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.2.post470%2Bg11795c5c%2Fdata%2FUrbanCoolingModel.zip?generation=1635965587831968&alt=media",
     "filesize": "1132530"
   },
   "Urban Flood Risk Mitigation": {
     "filename": "UrbanFloodMitigation.zip",
-    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.1.post531%2Bg2159bd07%2Fdata%2FUrbanFloodMitigation.zip?generation=1635279438322686&alt=media",
+    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.2.post470%2Bg11795c5c%2Fdata%2FUrbanFloodMitigation.zip?generation=1635965587873888&alt=media",
     "filesize": "187926"
   },
   "Wave Energy": {
     "filename": "WaveEnergy.zip",
-    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.1.post531%2Bg2159bd07%2Fdata%2FWaveEnergy.zip?generation=1635279440783668&alt=media",
+    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.2.post470%2Bg11795c5c%2Fdata%2FWaveEnergy.zip?generation=1635965589023191&alt=media",
     "filesize": "77718614",
     "labelSuffix": "(required to run model)"
   },
   "Wind Energy": {
     "filename": "WindEnergy.zip",
-    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.1.post531%2Bg2159bd07%2Fdata%2FWindEnergy.zip?generation=1635279438917894&alt=media",
+    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.2.post470%2Bg11795c5c%2Fdata%2FWindEnergy.zip?generation=1635965588286885&alt=media",
     "filesize": "5436801",
     "labelSuffix": "(required to run model)"
   },
   "Global DEM & Landmass Polygon": {
     "filename": "Base_Data.zip",
     "labelSuffix": "(required for Wind & Wave Energy)",
-    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.1.post531%2Bg2159bd07%2Fdata%2FBase_Data.zip?generation=1635279441197141&alt=media",
+    "url": "https://www.googleapis.com/download/storage/v1/b/releases.naturalcapitalproject.org/o/invest%2F3.9.2.post470%2Bg11795c5c%2Fdata%2FBase_Data.zip?generation=1635965589677317&alt=media",
     "filesize": "151372182"
   }
 }

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -133,21 +133,27 @@ body {
 
 /* Home Tab */
 
-.invest-list-group {
-	display: flex;
-	flex-direction: column;
-	flex-wrap: wrap;
+.invest-list-container {
 	height: 87vh;
 	overflow-y: auto;
 }
 
+.invest-list-group {
+	/*do not constrain height here because it can cause more
+	columns to be created. Constrain it in parent instead.*/
+	display: block;
+	column-count: 2;
+	white-space: nowrap;
+}
+
 .invest-list-group .list-group-item {
-	width: auto;
 	border-top: none;
 	border-right: none;
 	border-left: none;
 	border-bottom: 1px solid rgba(0,0,0,.125);
 	margin-bottom: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 
 .invest-list-group .list-group-item:last-child {

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -1,6 +1,7 @@
 body {
 	--invest-green: #148F68;
 	background-color: rgba(0,0,0,0);
+	font-size: 16px;
 	margin: 0;
 	padding: 1rem;
 	overflow-y: hidden;

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -132,19 +132,36 @@ body {
 
 /* Home Tab */
 
-.invest-list-table {
-	display: block;
+.invest-list-group {
+	display: flex;
+	flex-direction: column;
+	flex-wrap: wrap;
 	height: 87vh;
 	overflow-y: auto;
 }
 
-.invest-list-table .table td {
+.invest-list-group .list-group-item {
+	width: auto;
 	border-top: none;
-	border-bottom: 1px solid #dee2e6;
+	border-right: none;
+	border-left: none;
+	border-bottom: 1px solid rgba(0,0,0,.125);
+	margin-bottom: 0;
+}
+
+.invest-list-group .list-group-item:last-child {
+	border-radius: 0;
 }
 
 .invest-button {
 	color: var(--invest-green);
+	font-weight: 600;
+}
+
+.invest-button:hover {
+	color: white;
+	background-color: var(--invest-green);
+	opacity: 75%;
 	font-weight: 600;
 }
 

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -1,7 +1,10 @@
+:root {
+	font-size: 16px;
+}
+
 body {
 	--invest-green: #148F68;
 	background-color: rgba(0,0,0,0);
-	font-size: 16px;
 	margin: 0;
 	padding: 1rem;
 	overflow-y: hidden;

--- a/tests/binary_tests/puppet.test.js
+++ b/tests/binary_tests/puppet.test.js
@@ -160,15 +160,14 @@ test('Run a real invest model', async () => {
     doc, 'button', { name: 'Cancel' }, { timeout: extraTime }
   );
   await downloadModalCancel.click();
-  // Resorting to a class selector because we have two tables to differentiate
-  // Also, need to get the modelButton from w/in this table because there are
-  // buttons with the same name in the Recent Jobs container.
-  const investTable = await page.$('.invest-list-table');
+  // We need to get the modelButton from w/in this list-group because there
+  // are buttons with the same name in the Recent Jobs container.
+  const investModels = await page.$('.invest-list-group');
   await page.screenshot({ path: `${SCREENSHOT_PREFIX}2-models-list.png` });
 
   // Setting up Recreation model because it has very few data requirements
   const modelButton = await findByRole(
-    investTable, 'button', { name: /Visitation/ }
+    investModels, 'button', { name: /Visitation/ }
   );
   await modelButton.click();
   await page.screenshot({ path: `${SCREENSHOT_PREFIX}3-model-tab.png` });


### PR DESCRIPTION
This PR fixes #121. It orders the model list alphabetically by the model title text. It always keeps CBC Precprocessor before CBC model. 

It also wraps the list into two columns so that all the buttons are visible onscreen without scrolling.

Bonus: I updated the invest version to the HEAD of `release/3.10` , which is all we need to fix #184 