### PR TITLE
replacing event.target with event.currentTarget in event handlers

### DIFF
--- a/src/renderer/components/DataDownloadModal/index.jsx
+++ b/src/renderer/components/DataDownloadModal/index.jsx
@@ -72,17 +72,17 @@ export class DataDownloadModal extends React.Component {
     } = this.state;
     const newCheckList = Object.fromEntries(
       Object.entries(dataListCheckBoxes).map(
-        ([k, v]) => [k, event.target.checked]
+        ([k, v]) => [k, event.currentTarget.checked]
       )
     );
     let selectedLinks;
-    if (event.target.checked) {
+    if (event.currentTarget.checked) {
       selectedLinks = allLinksArray;
     } else {
       selectedLinks = [];
     }
     this.setState({
-      allDataCheck: event.target.checked,
+      allDataCheck: event.currentTarget.checked,
       dataListCheckBoxes: newCheckList,
       selectedLinksArray: selectedLinks,
     });
@@ -91,7 +91,7 @@ export class DataDownloadModal extends React.Component {
   handleCheckList(event, modelName) {
     let { selectedLinksArray, dataListCheckBoxes } = this.state;
     const { url } = sampledataRegistry[modelName];
-    if (event.target.checked) {
+    if (event.currentTarget.checked) {
       selectedLinksArray.push(url);
       dataListCheckBoxes[modelName] = true;
     } else {

--- a/src/renderer/components/HomeTab/index.jsx
+++ b/src/renderer/components/HomeTab/index.jsx
@@ -24,7 +24,7 @@ export default class HomeTab extends React.PureComponent {
   }
 
   handleClick(event) {
-    const { value } = event.target;
+    const { value } = event.currentTarget;
     const { investList, openInvestModel } = this.props;
     const modelRunName = investList[value].model_name;
     const job = new InvestJob({

--- a/src/renderer/components/ResourcesLinks/index.jsx
+++ b/src/renderer/components/ResourcesLinks/index.jsx
@@ -38,7 +38,7 @@ const FORUM_TAGS = {
  */
 function handleClick(event) {
   event.preventDefault();
-  shell.openExternal(event.target.href);
+  shell.openExternal(event.currentTarget.href);
 }
 
 /** Render model-relevant links to the User's Guide and Forum.

--- a/src/renderer/components/SettingsModal/index.jsx
+++ b/src/renderer/components/SettingsModal/index.jsx
@@ -88,7 +88,8 @@ export default class SettingsModal extends React.Component {
 
   handleChange(event) {
     const newSettings = { ...this.state.localSettings };
-    newSettings[event.target.name] = event.target.value;
+    const { name, value } = event.currentTarget;
+    newSettings[name] = value;
     this.setState({
       localSettings: newSettings,
     });

--- a/src/renderer/components/SetupTab/ArgInput/index.jsx
+++ b/src/renderer/components/SetupTab/ArgInput/index.jsx
@@ -71,7 +71,7 @@ Feedback.defaultProps = {
 function dragOverHandler(event) {
   event.preventDefault();
   event.stopPropagation();
-  if (event.target.disabled) {
+  if (event.currentTarget.disabled) {
     event.dataTransfer.dropEffect = 'none';
   } else {
     event.dataTransfer.dropEffect = 'copy';
@@ -81,11 +81,11 @@ function dragOverHandler(event) {
 function dragEnterHandler(event) {
   event.preventDefault();
   event.stopPropagation();
-  if (event.target.disabled) {
+  if (event.currentTarget.disabled) {
     event.dataTransfer.dropeffect = 'none';
   } else {
     event.dataTransfer.dropEffect = 'copy';
-    event.target.classList.add('input-dragging');
+    event.currentTarget.classList.add('input-dragging');
   }
 }
 
@@ -93,7 +93,7 @@ function dragLeavingHandler(event) {
   event.preventDefault();
   event.stopPropagation();
   event.dataTransfer.dropEffect = 'copy';
-  event.target.classList.remove('input-dragging');
+  event.currentTarget.classList.remove('input-dragging');
 }
 
 export default class ArgInput extends React.PureComponent {

--- a/src/renderer/components/SetupTab/ArgsForm/index.jsx
+++ b/src/renderer/components/SetupTab/ArgsForm/index.jsx
@@ -74,12 +74,12 @@ export default class ArgsForm extends React.Component {
   inputDropHandler(event) {
     event.preventDefault();
     event.stopPropagation();
-    event.target.classList.remove('input-dragging');
+    event.currentTarget.classList.remove('input-dragging');
     // Don't take any action on disabled elements
-    if (event.target.disabled) {
+    if (event.currentTarget.disabled) {
       return;
     }
-    const { name } = event.target; // the arg's key and type
+    const { name } = event.currentTarget; // the arg's key and type
     // TODO: could add more filters based on argType (e.g. only show .csv)
     const fileList = event.dataTransfer.files;
     if (fileList.length !== 1) {
@@ -93,20 +93,20 @@ export default class ArgsForm extends React.Component {
 
   handleChange(event) {
     /** Pass input value up to SetupTab for storage & validation. */
-    const { name, value } = event.target;
+    const { name, value } = event.currentTarget;
     this.props.updateArgValues(name, value);
   }
 
   handleBoolChange(event) {
     /** Handle changes from boolean inputs that submit strings */
-    const { name, value } = event.target;
+    const { name, value } = event.currentTarget;
     const boolVal = boolStringToBoolean(value);
     this.props.updateArgValues(name, boolVal);
   }
 
   async selectFile(event) {
     /** Handle clicks on browse-button inputs */
-    const { name, value } = event.target; // the arg's key and type
+    const { name, value } = event.currentTarget; // the arg's key and type
     const prop = (value === 'directory') ? 'openDirectory' : 'openFile';
     // TODO: could add more filters based on argType (e.g. only show .csv)
     const data = await ipcRenderer.invoke(

--- a/src/static/about.html
+++ b/src/static/about.html
@@ -149,7 +149,7 @@
 
     function handleClick(event) {
       event.preventDefault();
-      shell.openExternal(event.target.href);
+      shell.openExternal(event.currentTarget.href);
     }
   </script>
 </html>

--- a/src/static/report_a_problem.html
+++ b/src/static/report_a_problem.html
@@ -42,7 +42,7 @@
     }
     function handleLinkClick(event) {
       event.preventDefault();
-      shell.openExternal(event.target.href);
+      shell.openExternal(event.currentTarget.href);
     }
   </script>
 </html>

--- a/tests/renderer/setuptab.test.js
+++ b/tests/renderer/setuptab.test.js
@@ -195,6 +195,23 @@ describe('Arguments form interactions', () => {
     });
   });
 
+  test('Browse button populates an input - test click on child svg', async () => {
+    spec.args.arg.type = 'csv';
+    const {
+      findByRole, findByLabelText
+    } = renderSetupFromSpec(spec, uiSpec);
+
+    const filepath = 'grilled_cheese.csv';
+    const mockDialogData = { filePaths: [filepath] };
+    ipcRenderer.invoke.mockResolvedValue(mockDialogData);
+    const btn = await findByRole('button', { name: /browse for/ });
+    // Click on a target element nested within the button to make
+    // sure the handler still works correctly.
+    fireEvent.click(btn.querySelector('svg'));
+    expect(await findByLabelText(`${spec.args.arg.name}`))
+      .toHaveValue(filepath);
+  });
+
   test('Change value & get feedback on a required input', async () => {
     spec.args.arg.type = 'directory';
     spec.args.arg.required = true;


### PR DESCRIPTION
This fixes #189 

`event.currentTarget` seems like it's always the right choice when the event handler function is attached to the same node that has attributes/properties we want to pass to the function. If we were registering the handler on a parent node where it could be shared among children, then we might have a use-case for `event.target`, but that's not a pattern we've been using thus far.
