### PR TITLE
Bugfix/87 minor UI issues

### DIFF
--- a/src/main/ipcMainChannels.js
+++ b/src/main/ipcMainChannels.js
@@ -1,6 +1,7 @@
 export const ipcMainChannels = {
   SHOW_OPEN_DIALOG: 'show-open-dialog',
   SHOW_SAVE_DIALOG: 'show-save-dialog',
+  SHOW_ITEM_IN_FOLDER: 'show-item-in-folder',
   DOWNLOAD_URL: 'download-url',
   INVEST_RUN: 'invest-run',
   INVEST_KILL: 'invest-kill',

--- a/src/main/menubar.js
+++ b/src/main/menubar.js
@@ -1,3 +1,5 @@
+import path from 'path';
+
 import { app, BrowserWindow } from 'electron'; // eslint-disable-line import/no-extraneous-dependencies
 
 import setupContextMenu from './setupContextMenu';
@@ -138,6 +140,8 @@ function openReportWindow(parentWindow, isDevMode) {
       enableRemoteModule: false,
       nodeIntegration: true,
       minimumFontSize: 18,
+      preload: path.join(__dirname, '..', 'preload.js'),
+      defaultEncoding: 'UTF-8',
     },
   });
   setupContextMenu(child);

--- a/src/main/setupDialogs.js
+++ b/src/main/setupDialogs.js
@@ -1,6 +1,7 @@
 import {
   ipcMain,
   dialog,
+  shell,
 } from 'electron';
 
 import { ipcMainChannels } from './ipcMainChannels';
@@ -17,6 +18,12 @@ export default function setupDialogs() {
     ipcMainChannels.SHOW_SAVE_DIALOG, async (event, options) => {
       const result = await dialog.showSaveDialog(options);
       return result;
+    }
+  );
+
+  ipcMain.on(
+    ipcMainChannels.SHOW_ITEM_IN_FOLDER, (event, filepath) => {
+      shell.showItemInFolder(filepath);
     }
   );
 }

--- a/src/renderer/app.jsx
+++ b/src/renderer/app.jsx
@@ -259,7 +259,7 @@ export default class App extends React.Component {
         <TabPane
           key={id}
           eventKey={id}
-          title={job.modelHumanName}
+          aria-label={`${job.modelHumanName} tab`}
         >
           <InvestTab
             job={job}
@@ -341,7 +341,10 @@ export default class App extends React.Component {
             id="top-tab-content"
             onDragOver={dragOverHandlerNone}
           >
-            <TabPane eventKey="home" title="Home">
+            <TabPane
+              eventKey="home"
+              aria-label="home tab"
+            >
               {(investList)
                 ? (
                   <HomeTab

--- a/src/renderer/components/HomeTab/index.jsx
+++ b/src/renderer/components/HomeTab/index.jsx
@@ -62,7 +62,6 @@ export default class HomeTab extends React.PureComponent {
           key={model}
           className="invest-button"
           title={model}
-          aria-label={`open ${model} model`}
           action
           onClick={() => this.handleClick(model)}
         >

--- a/src/renderer/components/HomeTab/index.jsx
+++ b/src/renderer/components/HomeTab/index.jsx
@@ -61,6 +61,8 @@ export default class HomeTab extends React.PureComponent {
         <ListGroup.Item
           key={model}
           className="invest-button"
+          title={model}
+          aria-label={`open ${model} model`}
           action
           onClick={() => this.handleClick(model)}
         >

--- a/src/renderer/components/InvestTab/index.jsx
+++ b/src/renderer/components/InvestTab/index.jsx
@@ -1,7 +1,7 @@
 import path from 'path';
 import React from 'react';
 import PropTypes from 'prop-types';
-import { ipcRenderer, shell } from 'electron';
+import { ipcRenderer } from 'electron';
 
 import TabPane from 'react-bootstrap/TabPane';
 import TabContent from 'react-bootstrap/TabContent';
@@ -42,7 +42,7 @@ async function investGetSpec(modelName) {
 }
 
 function handleOpenWorkspace(logfile) {
-  shell.showItemInFolder(logfile);
+  ipcRenderer.send(ipcMainChannels.SHOW_ITEM_IN_FOLDER, logfile);
 }
 
 /**

--- a/src/renderer/components/InvestTab/index.jsx
+++ b/src/renderer/components/InvestTab/index.jsx
@@ -279,7 +279,10 @@ export default class InvestTab extends React.Component {
           </Col>
           <Col className="invest-main-col">
             <TabContent>
-              <TabPane eventKey="setup" title="Setup">
+              <TabPane
+                eventKey="setup"
+                aria-label="model setup tab"
+              >
                 <SetupTab
                   pyModuleName={modelSpec.pyname}
                   modelName={modelSpec.model_name}
@@ -293,7 +296,10 @@ export default class InvestTab extends React.Component {
                   executeClicked={this.state.executeClicked}
                 />
               </TabPane>
-              <TabPane eventKey="log" title="Log">
+              <TabPane
+                eventKey="log"
+                aria-label="model log tab"
+              >
                 <LogTab
                   logfile={logfile}
                   executeClicked={executeClicked}

--- a/src/renderer/components/ResourcesLinks/index.jsx
+++ b/src/renderer/components/ResourcesLinks/index.jsx
@@ -61,11 +61,21 @@ export default function ResourcesTab(props) {
   }
   return (
     <React.Fragment>
-      <a href={userGuideURL} onClick={handleClick}>
+      <a
+        href={userGuideURL}
+        title={userGuideURL}
+        aria-label="go to user guide in web browser"
+        onClick={handleClick}
+      >
         <MdOpenInNew className="mr-1" />
         User Guide
       </a>
-      <a href={forumURL} onClick={handleClick}>
+      <a
+        href={forumURL}
+        title={forumURL}
+        aria-label="go to user support forum in web browser"
+        onClick={handleClick}
+      >
         <MdOpenInNew className="mr-1" />
         Frequently Asked Questions
       </a>

--- a/src/renderer/components/SetupTab/ArgInput/index.jsx
+++ b/src/renderer/components/SetupTab/ArgInput/index.jsx
@@ -182,8 +182,8 @@ export default class ArgInput extends React.PureComponent {
                   value={value || ''} // empty string is handled better than `undefined`
                   onChange={handleChange}
                   onFocus={handleChange}
-                  isValid={touched && isValid}
-                  isInvalid={validationMessage}
+                  isValid={enabled && touched && isValid}
+                  isInvalid={enabled && validationMessage}
                   disabled={!enabled}
                   onDrop={inputDropHandler}
                   onDragOver={dragOverHandler}

--- a/src/renderer/components/SetupTab/ArgInput/index.jsx
+++ b/src/renderer/components/SetupTab/ArgInput/index.jsx
@@ -36,13 +36,24 @@ function filterSpatialOverlapFeedback(message, filepath) {
 function FormLabel(props) {
   return (
     <Form.Label column sm="3" htmlFor={props.argkey}>
-      {props.children}
+      <span>
+        {props.argname}
+        <em>
+          {
+            (typeof props.required === 'boolean' && !props.required)
+              ? ' (optional)' : ''
+          }
+        </em>
+      </span>
     </Form.Label>
   );
 }
 FormLabel.propTypes = {
   argkey: PropTypes.string.isRequired,
-  children: PropTypes.element.isRequired,
+  argname: PropTypes.string.isRequired,
+  required: PropTypes.oneOfType(
+    [PropTypes.string, PropTypes.bool]
+  ),
 };
 
 function Feedback(props) {
@@ -154,12 +165,21 @@ export default class ArgInput extends React.PureComponent {
           // this grays out the label but doesn't actually disable the field
           className={className}
         >
-          <FormLabel argkey={argkey}>
-            <span>
+          <FormLabel
+            argkey={argkey}
+            argname={argSpec.name}
+            required={argSpec.required}
+          />
+            {/*<span>
               {argSpec.name}
-              <em>{('required' in argSpec) ? ' (optional)' : ''}</em>
+              <em>
+                {
+                  (typeof argSpec.required === 'boolean' && !argSpec.required)
+                    ? ' (optional)' : ''
+                }
+              </em>
             </span>
-          </FormLabel>
+  */}
           <Col sm="8">
             <InputGroup>
               <div className="d-flex flex-nowrap w-100">
@@ -230,9 +250,11 @@ export default class ArgInput extends React.PureComponent {
           data-testid={`group-${argkey}`}
           className={className}
         >
-          <FormLabel argkey={argkey}>
-            <span>{argSpec.name}</span>
-          </FormLabel>
+          <FormLabel
+            argkey={argkey}
+            argname={argSpec.name}
+            required={argSpec.required}
+          />
           <Col sm="8" className="text-nowrap">
             <AboutModal argument={argSpec} />
             <Form.Check
@@ -270,9 +292,11 @@ export default class ArgInput extends React.PureComponent {
           data-testid={`group-${argkey}`}
           className={className}
         >
-          <FormLabel argkey={argkey}>
-            <span>{argSpec.name}</span>
-          </FormLabel>
+          <FormLabel
+            argkey={argkey}
+            argname={argSpec.name}
+            required={argSpec.required}
+          />
           <Col sm="4">
             <InputGroup>
               <div className="d-flex flex-nowrap w-100">

--- a/src/renderer/components/SetupTab/ArgInput/index.jsx
+++ b/src/renderer/components/SetupTab/ArgInput/index.jsx
@@ -170,16 +170,6 @@ export default class ArgInput extends React.PureComponent {
             argname={argSpec.name}
             required={argSpec.required}
           />
-            {/*<span>
-              {argSpec.name}
-              <em>
-                {
-                  (typeof argSpec.required === 'boolean' && !argSpec.required)
-                    ? ' (optional)' : ''
-                }
-              </em>
-            </span>
-  */}
           <Col sm="8">
             <InputGroup>
               <div className="d-flex flex-nowrap w-100">
@@ -297,9 +287,9 @@ export default class ArgInput extends React.PureComponent {
             argname={argSpec.name}
             required={argSpec.required}
           />
-          <Col sm="4">
+          <Col sm="8">
             <InputGroup>
-              <div className="d-flex flex-nowrap w-100">
+              <div className="d-flex flex-nowrap w-auto">
                 <AboutModal argument={argSpec} />
                 <Form.Control
                   id={argkey}

--- a/src/renderer/components/SetupTab/ArgInput/index.jsx
+++ b/src/renderer/components/SetupTab/ArgInput/index.jsx
@@ -157,6 +157,7 @@ export default class ArgInput extends React.PureComponent {
           <FormLabel argkey={argkey}>
             <span>
               {argSpec.name}
+              <em>{('required' in argSpec) ? ' (optional)' : ''}</em>
             </span>
           </FormLabel>
           <Col sm="8">

--- a/src/renderer/components/SetupTab/ArgInput/index.jsx
+++ b/src/renderer/components/SetupTab/ArgInput/index.jsx
@@ -170,7 +170,7 @@ export default class ArgInput extends React.PureComponent {
             argname={argSpec.name}
             required={argSpec.required}
           />
-          <Col sm="8">
+          <Col>
             <InputGroup>
               <div className="d-flex flex-nowrap w-100">
                 <AboutModal argument={argSpec} />
@@ -245,7 +245,7 @@ export default class ArgInput extends React.PureComponent {
             argname={argSpec.name}
             required={argSpec.required}
           />
-          <Col sm="8" className="text-nowrap">
+          <Col className="text-nowrap">
             <AboutModal argument={argSpec} />
             <Form.Check
               id={argkey}
@@ -287,7 +287,7 @@ export default class ArgInput extends React.PureComponent {
             argname={argSpec.name}
             required={argSpec.required}
           />
-          <Col sm="8">
+          <Col>
             <InputGroup>
               <div className="d-flex flex-nowrap w-auto">
                 <AboutModal argument={argSpec} />

--- a/src/renderer/components/SetupTab/ArgsForm/index.jsx
+++ b/src/renderer/components/SetupTab/ArgsForm/index.jsx
@@ -106,6 +106,7 @@ export default class ArgsForm extends React.Component {
 
   async selectFile(event) {
     /** Handle clicks on browse-button inputs */
+    console.dir(event.target)
     const { name, value } = event.target; // the arg's key and type
     const prop = (value === 'directory') ? 'openDirectory' : 'openFile';
     // TODO: could add more filters based on argType (e.g. only show .csv)

--- a/src/renderer/components/SetupTab/index.jsx
+++ b/src/renderer/components/SetupTab/index.jsx
@@ -254,10 +254,7 @@ export default class SetupTab extends React.Component {
    * @returns {undefined}
    */
   updateArgValues(key, value) {
-    console.log(key)
-    console.log(value)
     const { argsValues } = this.state;
-    console.log(argsValues)
     argsValues[key].value = value;
     argsValues[key].touched = true;
 

--- a/src/renderer/components/SetupTab/index.jsx
+++ b/src/renderer/components/SetupTab/index.jsx
@@ -312,7 +312,11 @@ export default class SetupTab extends React.Component {
           keyset.delete(key);
         });
       });
-      // validated all, so ones left in keyset are valid
+      // validated all, so ones left in keyset are either valid
+      // or their "required" condition was unmet and so they were
+      // not validated and will appear disabled in the UI. Disabled
+      // inputs will not display a validation state, so it's okay
+      // to simply set all these as valid here.
       keyset.forEach((k) => {
         argsValidation[k].valid = true;
         argsValidation[k].validationMessage = '';

--- a/src/renderer/components/SetupTab/index.jsx
+++ b/src/renderer/components/SetupTab/index.jsx
@@ -254,7 +254,10 @@ export default class SetupTab extends React.Component {
    * @returns {undefined}
    */
   updateArgValues(key, value) {
+    console.log(key)
+    console.log(value)
     const { argsValues } = this.state;
+    console.log(argsValues)
     argsValues[key].value = value;
     argsValues[key].touched = true;
 

--- a/src/renderer/ui_config.js
+++ b/src/renderer/ui_config.js
@@ -49,19 +49,26 @@ const uiSpec = {
     order: [
       ["workspace_dir", "results_suffix"],
       ["lulc_cur_path", "carbon_pools_path"],
-      ["calc_sequestration", "lulc_cur_year", "lulc_fut_path", "lulc_fut_year"],
+      ["calc_sequestration", "lulc_fut_path"],
       ["do_redd", "lulc_redd_path"],
-      ["do_valuation", "price_per_metric_ton_of_c", "discount_rate", "rate_change"]
+      [
+        "do_valuation",
+        "lulc_cur_year",
+        "lulc_fut_year",
+        "price_per_metric_ton_of_c",
+        "discount_rate",
+        "rate_change",
+      ],
     ],
     enabledFunctions: {
-      lulc_cur_year: isSufficient.bind(null, 'calc_sequestration'),
-      lulc_fut_year: isSufficient.bind(null, 'calc_sequestration'),
       lulc_fut_path: isSufficient.bind(null, 'calc_sequestration'),
 
       do_redd: isSufficient.bind(null, 'calc_sequestration'),
       lulc_redd_path: isSufficient.bind(null, 'do_redd'),
 
       do_valuation: isSufficient.bind(null, 'calc_sequestration'),
+      lulc_cur_year: isSufficient.bind(null, 'do_valuation'),
+      lulc_fut_year: isSufficient.bind(null, 'do_valuation'),
       price_per_metric_ton_of_c: isSufficient.bind(null, 'do_valuation'),
       discount_rate: isSufficient.bind(null, 'do_valuation'),
       rate_change: isSufficient.bind(null, 'do_valuation'),

--- a/src/renderer/ui_config.js
+++ b/src/renderer/ui_config.js
@@ -98,14 +98,18 @@ const uiSpec = {
   },
   coastal_vulnerability: {
     order: [
-      ["workspace_dir", "results_suffix"],
-      ["aoi_vector_path", "model_resolution"],
-      ["landmass_vector_path", "wwiii_vector_path", "max_fetch_distance"],
-      ["bathymetry_raster_path", "dem_path", "dem_averaging_radius"],
-      ["shelf_contour_vector_path", "habitat_table_path"],
-      ["geomorphology_vector_path", "geomorphology_fill_value"],
-      ["population_raster_path", "population_radius"],
-      ["slr_vector_path", "slr_field"]
+      ['workspace_dir', 'results_suffix'],
+      ['aoi_vector_path', 'model_resolution', 'landmass_vector_path'],
+      ['bathymetry_raster_path', 'wwiii_vector_path', 'max_fetch_distance'],
+      [
+        'habitat_table_path',
+        'shelf_contour_vector_path',
+        'dem_path',
+        'dem_averaging_radius',
+      ],
+      ['geomorphology_vector_path', 'geomorphology_fill_value'],
+      ['population_raster_path', 'population_radius'],
+      ['slr_vector_path', 'slr_field'],
     ],
     dropdownFunctions: {
       slr_field: ((state) => getVectorColumnNames(state.argsValues['slr_vector_path'].value))

--- a/src/static/report_a_problem.html
+++ b/src/static/report_a_problem.html
@@ -30,15 +30,21 @@
     </p>
   </body>
   <script>
-    const { shell } = require('electron');
-    const { getLogger } = require('../logger');
-    const logger = getLogger(__filename.split('/').slice(-1)[0]);
+    const { ipcRenderer, shell } = require('electron');
+    const { ipcMainChannels } = require('../main/ipcMainChannels');
+
+    const logger = window.Workbench.getLogger(
+      __filename.split('/').slice(-1)[0]
+    );
 
     logger.debug('PROBLEM REPORT: process dump');
     logger.debug(JSON.stringify(process, null, 2));
 
     function handleButtonClick() {
-      shell.showItemInFolder(logger.transports.file.getFile().path)
+      ipcRenderer.send(
+        ipcMainChannels.SHOW_ITEM_IN_FOLDER,
+        logger.transports.file.getFile().path
+      );
     }
     function handleLinkClick(event) {
       event.preventDefault();

--- a/src/static/report_a_problem.html
+++ b/src/static/report_a_problem.html
@@ -4,31 +4,30 @@
     <p>
       Please help us by reporting problems (nothing is too small or too large) to: 
       <a
-        href="https://community.naturalcapitalproject.org/c/experimental-software-tools/6"
+        href="https://community.naturalcapitalproject.org/"
         onClick="handleLinkClick(event)">
         https://community.naturalcapitalproject.org
       </a>
     </p>
     <p>
-      Please use the "Experimental Software Tools" category, include a
-      brief description of the problem, a screenshot if necessary,
-      and attach the log files that you can find using the button below.
-      (There may be multiple files with a ".log" extension.)
-      <b>Please include all the log files.</b>
+      If the problem is related to a specific InVEST model error,
+      please see the guidelines here for reporting problems:
+      <a
+        href="https://community.naturalcapitalproject.org/t/guidelines-for-posting-software-support-questions/24"
+        onClick="handleLinkClick(event)">
+        Guidelines for posting software support questions
+      </a>
+    </p>
+    <p>
+      If the problem seems related to this User Interface, rather than
+      with a specific InVEST model, please include a brief description
+      of the problem, a screenshot if necessary, and attach the log files
+      that you can find using the button below. There may be multiple files
+      with a ".log" extension; please include all the log files.
     </p>
     <button type="button" onclick="handleButtonClick()">
       Find My Logs
     </button>
-    <br/>
-    <br/>
-    <p>
-      View a list of the issues already on our todo list:
-    </p>
-      <a
-        href="https://github.com/natcap/invest-workbench/issues"
-        onClick="handleLinkClick(event)">
-        https://github.com/natcap/invest-workbench/issues
-      </a>
   </body>
   <script>
     const { ipcRenderer, shell } = require('electron');

--- a/src/static/report_a_problem.html
+++ b/src/static/report_a_problem.html
@@ -2,14 +2,18 @@
 <html lang="en">
   <body>
     <p>
-      Hello Workbench-alpha tester! 
-    </p>
-      Please help us by reporting problems (nothing is too small or too large) to:  davefisher@stanford.edu
+      Please help us by reporting problems (nothing is too small or too large) to: 
+      <a
+        href="https://community.naturalcapitalproject.org/c/experimental-software-tools/6"
+        onClick="handleLinkClick(event)">
+        https://community.naturalcapitalproject.org
+      </a>
     </p>
     <p>
-      Include a brief description of the problem and attach the log files
-      that you can find using the button below. (There may be multiple 
-      files with a ".log" extension.)
+      Please use the "Experimental Software Tools" category, include a
+      brief description of the problem, a screenshot if necessary,
+      and attach the log files that you can find using the button below.
+      (There may be multiple files with a ".log" extension.)
       <b>Please include all the log files.</b>
     </p>
     <button type="button" onclick="handleButtonClick()">
@@ -25,9 +29,6 @@
         onClick="handleLinkClick(event)">
         https://github.com/natcap/invest-workbench/issues
       </a>
-    <p>
-      If you have a github account, you're most welcome to join the discussions there too.
-    </p>
   </body>
   <script>
     const { ipcRenderer, shell } = require('electron');

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -377,7 +377,11 @@ body {
 }
 
 .arg-disable .form-label {
-	color: lightgray;
+	color: #a5a5a5;
+}
+
+.args-form .form-control:disabled {
+	color: #888888;
 }
 
 .args-form .form-group {

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -384,6 +384,10 @@ body {
 	align-items: center;
 }
 
+.args-form .form-label {
+	text-transform: capitalize;
+}
+
 .args-form .form-control {
 	font-family: monospace;
 	font-size:1.3rem;

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -355,8 +355,13 @@ body {
 
 .arg-group {
 	margin-top: 1.0rem;
-	margin-bottom: 2.0rem;
+	margin-bottom: 1.5rem;
+	padding-bottom: 0.5rem;
 	border-bottom: 1px dotted;
+}
+
+.arg-group:last-of-type {
+	border-bottom: none;
 }
 
 .arg-hide {

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -354,8 +354,9 @@ body {
 }
 
 .arg-group {
-	margin-top: 2.0rem;
+	margin-top: 1.0rem;
 	margin-bottom: 2.0rem;
+	border-bottom: 1px dotted;
 }
 
 .arg-hide {

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -342,9 +342,10 @@ body {
 .args-form {
 	height: 85vh;
 	width: 100%;
-	margin-left: 2rem;
 	overflow-y: auto;
 	overflow-x: hidden;
+	padding-left: 2rem;
+	padding-right: 1rem;
 }
 
 /* InVEST Argument Forms */

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -27,6 +27,11 @@ body {
 	padding-bottom: 0;
 }
 
+.navbar-brand:hover {
+	text-decoration-line: underline;
+	text-decoration-thickness: 3px;
+}
+
 .navbar-middle {
 	flex-shrink: 1;
 	min-width: 0;

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -365,6 +365,10 @@ body {
 	color: lightgray;
 }
 
+.args-form .form-group {
+	align-items: center;
+}
+
 .args-form .form-control {
 	font-family: monospace;
 	font-size:1.3rem;

--- a/tests/main/main.test.js
+++ b/tests/main/main.test.js
@@ -181,6 +181,7 @@ describe('createWindow', () => {
       ipcMainChannels.INVEST_RUN,
       ipcMainChannels.INVEST_KILL,
       ipcMainChannels.INVEST_READ_LOG,
+      ipcMainChannels.SHOW_ITEM_IN_FOLDER,
     ];
     createWindow();
     await waitFor(() => {

--- a/tests/renderer/app.test.js
+++ b/tests/renderer/app.test.js
@@ -39,7 +39,7 @@ const MOCK_INVEST_LIST = {
 const MOCK_VALIDATION_VALUE = [[['workspace_dir'], 'invalid because']];
 
 const SAMPLE_SPEC = {
-  model_name: 'Carbon Storage and Sequestration',
+  model_name: MOCK_MODEL_TITLE,
   pyname: 'natcap.invest.carbon',
   userguide_html: 'carbonstorage.html',
   args: {
@@ -86,7 +86,7 @@ describe('Various ways to open and close InVEST models', () => {
     );
 
     const carbon = await findByRole(
-      'button', { name: `open ${MOCK_MODEL_TITLE} model` }
+      'button', { name: MOCK_MODEL_TITLE }
     );
     fireEvent.click(carbon);
     const executeButton = await findByRole('button', { name: /Run/ });
@@ -190,7 +190,7 @@ describe('Various ways to open and close InVEST models', () => {
     } = render(<App />);
 
     const carbon = await findByRole(
-      'button', { name: `open ${MOCK_MODEL_TITLE} model` }
+      'button', { name: MOCK_MODEL_TITLE }
     );
     const homeTab = await findByRole('tabpanel', { name: 'home tab' });
 
@@ -620,7 +620,7 @@ describe('InVEST subprocess testing', () => {
     } = render(<App />);
 
     const carbon = await findByRole(
-      'button', { name: `open ${MOCK_MODEL_TITLE} model` }
+      'button', { name: MOCK_MODEL_TITLE }
     );
     fireEvent.click(carbon);
     const workspaceInput = await findByLabelText(
@@ -667,7 +667,7 @@ describe('InVEST subprocess testing', () => {
     } = render(<App />);
 
     const carbon = await findByRole(
-      'button', { name: `open ${MOCK_MODEL_TITLE} model` }
+      'button', { name: MOCK_MODEL_TITLE }
     );
     fireEvent.click(carbon);
     const workspaceInput = await findByLabelText(
@@ -725,7 +725,7 @@ describe('InVEST subprocess testing', () => {
     } = render(<App />);
 
     const carbon = await findByRole(
-      'button', { name: `open ${MOCK_MODEL_TITLE} model` }
+      'button', { name: MOCK_MODEL_TITLE }
     );
     fireEvent.click(carbon);
     const workspaceInput = await findByLabelText(
@@ -771,7 +771,7 @@ describe('InVEST subprocess testing', () => {
     } = render(<App />);
 
     const carbon = await findByRole(
-      'button', { name: `open ${MOCK_MODEL_TITLE} model` }
+      'button', { name: MOCK_MODEL_TITLE }
     );
     fireEvent.click(carbon);
     const workspaceInput = await findByLabelText(

--- a/tests/renderer/app.test.js
+++ b/tests/renderer/app.test.js
@@ -85,7 +85,9 @@ describe('Various ways to open and close InVEST models', () => {
       <App />
     );
 
-    const carbon = await findByRole('button', { name: MOCK_MODEL_TITLE });
+    const carbon = await findByRole(
+      'button', { name: `open ${MOCK_MODEL_TITLE} model` }
+    );
     fireEvent.click(carbon);
     const executeButton = await findByRole('button', { name: /Run/ });
     expect(executeButton).toBeDisabled();
@@ -172,7 +174,7 @@ describe('Various ways to open and close InVEST models', () => {
 
     const openButton = await findByRole('button', { name: 'Open' });
     fireEvent.click(openButton);
-    const homeTab = await findByRole('tabpanel', { name: /Home/ });
+    const homeTab = await findByRole('tabpanel', { name: 'home tab' });
     // expect we're on the same tab we started on instead of switching to Setup
     expect(homeTab.classList.contains('active')).toBeTruthy();
     // These are the calls that would have triggered if a file was selected
@@ -187,8 +189,10 @@ describe('Various ways to open and close InVEST models', () => {
       queryAllByRole,
     } = render(<App />);
 
-    const carbon = await findByRole('button', { name: MOCK_MODEL_TITLE });
-    const homeTab = await findByRole('tabpanel', { name: /Home/ });
+    const carbon = await findByRole(
+      'button', { name: `open ${MOCK_MODEL_TITLE} model` }
+    );
+    const homeTab = await findByRole('tabpanel', { name: 'home tab' });
 
     // Open a model tab and expect that it's active
     fireEvent.click(carbon);
@@ -615,7 +619,9 @@ describe('InVEST subprocess testing', () => {
       queryByText,
     } = render(<App />);
 
-    const carbon = await findByRole('button', { name: MOCK_MODEL_TITLE });
+    const carbon = await findByRole(
+      'button', { name: `open ${MOCK_MODEL_TITLE} model` }
+    );
     fireEvent.click(carbon);
     const workspaceInput = await findByLabelText(
       `${spec.args.workspace_dir.name}`
@@ -646,7 +652,7 @@ describe('InVEST subprocess testing', () => {
 
     // A recent job card should be rendered
     await getByRole('button', { name: 'InVEST' }).click();
-    const homeTab = await getByRole('tabpanel', { name: /Home/ });
+    const homeTab = await getByRole('tabpanel', { name: 'home tab' });
     const cardText = await within(homeTab)
       .findByText(`${path.resolve(fakeWorkspace)}`);
     expect(cardText).toBeInTheDocument();
@@ -660,7 +666,9 @@ describe('InVEST subprocess testing', () => {
       getByRole,
     } = render(<App />);
 
-    const carbon = await findByRole('button', { name: MOCK_MODEL_TITLE });
+    const carbon = await findByRole(
+      'button', { name: `open ${MOCK_MODEL_TITLE} model` }
+    );
     fireEvent.click(carbon);
     const workspaceInput = await findByLabelText(
       `${spec.args.workspace_dir.name}`
@@ -701,7 +709,7 @@ describe('InVEST subprocess testing', () => {
 
     // A recent job card should be rendered
     await getByRole('button', { name: 'InVEST' }).click();
-    const homeTab = await getByRole('tabpanel', { name: /Home/ });
+    const homeTab = await getByRole('tabpanel', { name: 'home tab' });
     const cardText = await within(homeTab)
       .findByText(`${path.resolve(fakeWorkspace)}`);
     expect(cardText).toBeInTheDocument();
@@ -716,7 +724,9 @@ describe('InVEST subprocess testing', () => {
       queryByText,
     } = render(<App />);
 
-    const carbon = await findByRole('button', { name: MOCK_MODEL_TITLE });
+    const carbon = await findByRole(
+      'button', { name: `open ${MOCK_MODEL_TITLE} model` }
+    );
     fireEvent.click(carbon);
     const workspaceInput = await findByLabelText(
       `${spec.args.workspace_dir.name}`
@@ -747,7 +757,7 @@ describe('InVEST subprocess testing', () => {
 
     // A recent job card should be rendered
     await getByRole('button', { name: 'InVEST' }).click();
-    const homeTab = await getByRole('tabpanel', { name: /Home/ });
+    const homeTab = await getByRole('tabpanel', { name: 'home tab' });
     const cardText = await within(homeTab)
       .findByText(`${path.resolve(fakeWorkspace)}`);
     expect(cardText).toBeInTheDocument();
@@ -760,7 +770,9 @@ describe('InVEST subprocess testing', () => {
       findByRole,
     } = render(<App />);
 
-    const carbon = await findByRole('button', { name: MOCK_MODEL_TITLE });
+    const carbon = await findByRole(
+      'button', { name: `open ${MOCK_MODEL_TITLE} model` }
+    );
     fireEvent.click(carbon);
     const workspaceInput = await findByLabelText(
       `${spec.args.workspace_dir.name}`

--- a/tests/renderer/investtab.test.js
+++ b/tests/renderer/investtab.test.js
@@ -14,6 +14,8 @@ import {
   fetchDatastackFromFile
 } from '../../src/renderer/server_requests';
 import InvestJob from '../../src/renderer/InvestJob';
+import setupDialogs from '../../src/main/setupDialogs';
+import { removeIpcMainListeners } from '../../src/main/main';
 
 jest.mock('../../src/renderer/server_requests');
 
@@ -61,6 +63,7 @@ describe('Sidebar Alert renders with data from a recent run', () => {
     fetchValidation.mockResolvedValue([]);
     const mockSpec = spec; // jest.mock not allowed to ref out-of-scope var
     jest.mock(UI_CONFIG_PATH, () => mockUISpec(mockSpec));
+    setupDialogs();
   });
 
   afterEach(() => {
@@ -71,6 +74,7 @@ describe('Sidebar Alert renders with data from a recent run', () => {
   afterAll(() => {
     jest.resetModules();
     jest.resetAllMocks();
+    removeIpcMainListeners();
   });
 
   test('final Traceback displays', async () => {

--- a/tests/renderer/setuptab.test.js
+++ b/tests/renderer/setuptab.test.js
@@ -281,7 +281,7 @@ describe('Arguments form interactions', () => {
 });
 
 describe('UI spec functionality', () => {
-  beforeAll(() => {
+  beforeEach(() => {
     fetchValidation.mockResolvedValue([]);
   });
 
@@ -311,6 +311,9 @@ describe('UI spec functionality', () => {
         }
       }
     };
+    // mock some validation state so that we can test that it only
+    // displays when an input is enabled.
+    fetchValidation.mockResolvedValue([[['arg4'], 'invalid because']]);
 
     const uiSpec = {
       order: [Object.keys(spec.args)],
@@ -349,6 +352,7 @@ describe('UI spec functionality', () => {
       expect(arg2).toBeEnabled();
       expect(arg3).toBeDisabled();
       expect(arg4).toBeEnabled();
+      expect(arg4).toHaveClass('is-invalid');
     });
 
     fireEvent.click(arg2, { target: { value: 'true' } });
@@ -356,6 +360,10 @@ describe('UI spec functionality', () => {
       expect(arg2).toBeEnabled();
       expect(arg3).toBeEnabled();
       expect(arg4).toBeDisabled();
+      // the disabled input's validation result has not changed,
+      // but the validation state should be hidden on disabled inputs.
+      expect(arg4).not.toHaveClass('is-invalid');
+      expect(arg4).not.toHaveClass('is-valid');
     });
   });
 

--- a/tests/renderer/setuptab.test.js
+++ b/tests/renderer/setuptab.test.js
@@ -250,7 +250,7 @@ describe('Arguments form interactions', () => {
     fetchValidation.mockResolvedValue([]);
     const { findByLabelText } = renderSetupFromSpec(spec, uiSpec);
 
-    const input = await findByLabelText(`${spec.args.arg.name}`);
+    const input = await findByLabelText(`${spec.args.arg.name} (optional)`);
 
     // An optional input with no value is valid, but green check
     // does not display until the input has been touched.


### PR DESCRIPTION
This PR fixes #87 . A couple of the items listed there were already fixed. Here's a screenshot showing the result of many of the fixes:

![wb_ui](https://user-images.githubusercontent.com/4071255/141492040-892a9825-0dfc-4595-a655-7b00835f431d.PNG)


Other items:
> Default hover text appears on all elements and is not helpful. We should remove it and maybe add it back for elements that would really benefit from it.

This was fixed by removing/adding title attributes as-needed. Presence of a `title` attribute triggers the default content for a tooltip. It's also sometimes used by screen-readers, but `aria-label` is much better for that purpose, so that was added when `title` was removed.

>Open Workspace button opens a native OS dialog, but on Windows it does not display on top of other open windows. So it's easy to think that the button didn't work.

The fix here was to move the electron API call to `main` process from `renderer`. That's where it should be anyway.