### PR TITLE
Bugfix/198 save python script

### DIFF
--- a/src/renderer/components/InvestTab/index.jsx
+++ b/src/renderer/components/InvestTab/index.jsx
@@ -285,7 +285,7 @@ export default class InvestTab extends React.Component {
               >
                 <SetupTab
                   pyModuleName={modelSpec.pyname}
-                  modelName={modelSpec.model_name}
+                  modelName={modelRunName}
                   argsSpec={argsSpec}
                   uiSpec={uiSpec}
                   argsInitValues={argsValues}

--- a/src/renderer/components/SetupTab/index.jsx
+++ b/src/renderer/components/SetupTab/index.jsx
@@ -194,13 +194,12 @@ export default class SetupTab extends React.Component {
    * @returns {undefined}
    */
   savePythonScript(filepath) {
-    const { modelName, pyModuleName } = this.props;
+    const { modelName } = this.props;
     const argsValues = this.insertNWorkers(this.state.argsValues);
     const argsDict = argsDictFromObject(argsValues);
     const payload = {
       filepath: filepath,
       modelname: modelName,
-      pyname: pyModuleName,
       args: JSON.stringify(argsDict),
     };
     saveToPython(payload);

--- a/tests/invest/flaskapp.test.js
+++ b/tests/invest/flaskapp.test.js
@@ -130,7 +130,6 @@ describe('requests to flask endpoints', () => {
     const payload = {
       filepath: filepath,
       modelname: modelName,
-      pyname: spec.pyname,
       args: JSON.stringify(argsDict),
     };
     await server_requests.saveToPython(payload);

--- a/tests/renderer/investtab.test.js
+++ b/tests/renderer/investtab.test.js
@@ -48,7 +48,7 @@ function renderInvestTab(job = DEFAULT_JOB) {
 describe('Sidebar Alert renders with data from a recent run', () => {
   const spec = {
     pyname: 'natcap.invest.foo',
-    model_name: 'FooModel',
+    model_name: 'Foo Model',
     args: {
       workspace: {
         name: 'Workspace',
@@ -158,7 +158,7 @@ describe('Sidebar Alert renders with data from a recent run', () => {
 describe('Save InVEST Model Setup Buttons', () => {
   const spec = {
     pyname: 'natcap.invest.foo',
-    model_name: 'FooModel',
+    model_name: 'Foo Model',
     args: {
       workspace: {
         name: 'Workspace',
@@ -243,11 +243,14 @@ describe('Save InVEST Model Setup Buttons', () => {
     await waitFor(() => {
       const results = saveToPython.mock.results[0].value;
       expect(Object.keys(results)).toEqual(expect.arrayContaining(
-        ['filepath', 'modelname', 'pyname', 'args']
+        ['filepath', 'modelname', 'args']
       ));
-      Object.keys(results).forEach((key) => {
-        expect(results[key]).not.toBeUndefined();
-      });
+      expect(typeof results.filepath).toBe('string');
+      expect(typeof results.modelname).toBe('string');
+      // guard against a common mistake of passing a model title
+      expect(results.modelname.split(' ')).toHaveLength(1);
+
+      expect(results.args).not.toBeUndefined();
       const args = JSON.parse(results.args);
       const argKeys = Object.keys(args);
       expect(argKeys).toEqual(expect.arrayContaining(expectedArgKeys));
@@ -361,7 +364,7 @@ describe('Save InVEST Model Setup Buttons', () => {
 describe('InVEST Run Button', () => {
   const spec = {
     pyname: 'natcap.invest.bar',
-    model_name: 'BarModel',
+    model_name: 'Bar Model',
     args: {
       a: {
         name: 'abar',


### PR DESCRIPTION
Fixes #198 

We were passing the model title (e.g. Carbon Storage and Sequestration) instead of the model name (e.g. carbon). I updated tests to catch that if it ever happens again. 

We were also passing the model's module name to this endpoint, but that's not being used at all so I also removed it from the payload.