### PR TITLE
Feature/200 settings dialog ux

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "invest": {
     "bucket": "releases.naturalcapitalproject.org",
     "fork": "natcap",
-    "version": "3.9.2.post470+g11795c5c",
+    "version": "3.9.2.post480+gc06f40d7",
     "target": {
       "macos": "mac_invest_binaries.zip",
       "windows": "windows_invest_binaries.zip"

--- a/src/main/ipcMainChannels.js
+++ b/src/main/ipcMainChannels.js
@@ -7,4 +7,5 @@ export const ipcMainChannels = {
   INVEST_KILL: 'invest-kill',
   INVEST_READ_LOG: 'invest-read-log',
   IS_FIRST_RUN: 'is-first-run',
+  GET_N_CPUS: 'get-n-cpus',
 };

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -24,6 +24,7 @@ import {
   setupInvestRunHandlers,
   setupInvestLogReaderHandler
 } from './setupInvestHandlers';
+import setupGetNCPUs from './setupGetNCPUs';
 import { ipcMainChannels } from './ipcMainChannels';
 import menuTemplate from './menubar';
 import ELECTRON_DEV_MODE from './isDevMode';
@@ -121,6 +122,7 @@ export const createWindow = async () => {
   setupInvestRunHandlers(investExe);
   setupInvestLogReaderHandler();
   setupContextMenu(mainWindow);
+  setupGetNCPUs();
 };
 
 export function removeIpcMainListeners() {

--- a/src/main/setupGetNCPUs.js
+++ b/src/main/setupGetNCPUs.js
@@ -1,0 +1,13 @@
+import os from 'os';
+
+import { ipcMain } from 'electron';
+
+import { ipcMainChannels } from './ipcMainChannels';
+
+export default function setupGetNCPUs() {
+  ipcMain.handle(
+    ipcMainChannels.GET_N_CPUS, () => {
+      return os.cpus().length;
+    }
+  );
+}

--- a/src/renderer/app.jsx
+++ b/src/renderer/app.jsx
@@ -329,6 +329,7 @@ export default class App extends React.Component {
                         investSettings={investSettings}
                         clearJobsStorage={this.clearRecentJobs}
                         showDownloadModal={() => this.showDownloadModal(true)}
+                        nCPU={this.props.nCPU}
                       />
                     )
                     : <div />
@@ -366,10 +367,12 @@ export default class App extends React.Component {
 
 App.propTypes = {
   isFirstRun: PropTypes.bool,
+  nCPU: PropTypes.number,
 };
 
-// Setting a default here mainly to make testing easy, so this prop
+// Setting a default here mainly to make testing easy, so these props
 // can be undefined for unrelated tests.
 App.defaultProps = {
   isFirstRun: false,
+  nCPU: 1,
 };

--- a/src/renderer/components/SettingsModal/index.jsx
+++ b/src/renderer/components/SettingsModal/index.jsx
@@ -1,12 +1,17 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import Accordion from 'react-bootstrap/Accordion';
 import Col from 'react-bootstrap/Col';
 import Row from 'react-bootstrap/Row';
 import Form from 'react-bootstrap/Form';
 import Button from 'react-bootstrap/Button';
 import Modal from 'react-bootstrap/Modal';
-import { MdSettings, MdClose } from 'react-icons/md';
+import {
+  MdSettings,
+  MdClose,
+} from 'react-icons/md';
+import { BsChevronExpand } from 'react-icons/bs';
 
 import { getDefaultSettings } from './SettingsStorage';
 
@@ -92,8 +97,8 @@ export default class SettingsModal extends React.Component {
           </Modal.Header>
           <Modal.Body>
             <Form.Group as={Row}>
-              <Form.Label column sm="8" htmlFor="logging-select">Logging threshold</Form.Label>
-              <Col sm="4">
+              <Form.Label column sm="7" htmlFor="logging-select">Logging threshold</Form.Label>
+              <Col sm="5">
                 <Form.Control
                   id="logging-select"
                   as="select"
@@ -111,18 +116,12 @@ export default class SettingsModal extends React.Component {
               (this.state.nWorkersOptions)
                 ? (
                   <Form.Group as={Row}>
-                    <Form.Label column sm="9" htmlFor="nworkers-select">
-                      Taskgraph n_workers parameter
-                      <ul>
-                        <li>-1: (recommended) synchronous mode</li>
-                        <li>0: single process with threaded task management</li>
-                        <li>
-                          n CPUs: depending on the InVEST model, tasks may execute
-                          in parallel using this many processes.
-                        </li>
-                      </ul>
-                    </Form.Label>
-                    <Col sm="3">
+                    <Col sm="7">
+                      <Form.Label htmlFor="nworkers-select">
+                        Taskgraph n_workers parameter
+                      </Form.Label>
+                    </Col>
+                    <Col sm="5">
                       <Form.Control
                         id="nworkers-select"
                         as="select"
@@ -136,17 +135,43 @@ export default class SettingsModal extends React.Component {
                         )}
                       </Form.Control>
                     </Col>
+                    <Accordion>
+                      <Accordion.Toggle
+                        as={Button}
+                        variant="secondary-outline"
+                        eventKey="0"
+                        className="pt-0"
+                      >
+                        <BsChevronExpand className="mx-1" />
+                        <span className="small"><u>more info</u></span>
+                      </Accordion.Toggle>
+                      <Accordion.Collapse eventKey="0">
+                        <ul>
+                          <li>-1: (recommended) synchronous mode</li>
+                          <li>0: single process with threaded task management</li>
+                          <li>
+                            n CPUs: depending on the InVEST model, tasks may execute
+                            in parallel using this many processes.
+                          </li>
+                        </ul>
+                      </Accordion.Collapse>
+                    </Accordion>
                   </Form.Group>
                 )
                 : <div />
             }
-            <Button
-              variant="secondary"
-              onClick={this.handleReset}
-              type="button"
-            >
-              Reset to Defaults
-            </Button>
+            <Row className="justify-content-end">
+              <Col sm="5">
+                <Button
+                  variant="secondary"
+                  onClick={this.handleReset}
+                  type="button"
+                  className="w-100"
+                >
+                  Reset to Defaults
+                </Button>
+              </Col>
+            </Row>
             <hr />
             <Button
               variant="primary"

--- a/src/renderer/components/SettingsModal/index.jsx
+++ b/src/renderer/components/SettingsModal/index.jsx
@@ -137,7 +137,7 @@ export default class SettingsModal extends React.Component {
                         onChange={this.handleChange}
                       >
                         {this.state.nWorkersOptions.map(
-                          (opt) => <option value={opt[0]}key={opt[0]}>{opt[1]}</option>
+                          (opt) => <option value={opt[0]} key={opt[0]}>{opt[1]}</option>
                         )}
                       </Form.Control>
                     </Col>

--- a/src/renderer/components/SettingsModal/index.jsx
+++ b/src/renderer/components/SettingsModal/index.jsx
@@ -83,6 +83,13 @@ export default class SettingsModal extends React.Component {
         <Modal show={this.state.show} onHide={this.handleClose}>
           <Modal.Header>
             <Modal.Title>InVEST Settings</Modal.Title>
+            <Button
+              variant="secondary"
+              onClick={this.handleClose}
+              className="float-right"
+            >
+              Cancel
+            </Button>
           </Modal.Header>
           <Modal.Body>
             <Form.Group as={Row}>
@@ -102,7 +109,7 @@ export default class SettingsModal extends React.Component {
               </Col>
             </Form.Group>
             <Form.Group as={Row}>
-              <Form.Label column sm="8" htmlFor="nworkers-text">
+              <Form.Label column sm="8" htmlFor="nworkers-select">
                 Taskgraph n_workers parameter
                 <br />
                 (must be an integer &gt;= -1)
@@ -145,11 +152,6 @@ export default class SettingsModal extends React.Component {
             </Button>
             <div>(no invest workspaces will be deleted)</div>
           </Modal.Body>
-          <Modal.Footer>
-            <Button variant="secondary" onClick={this.handleClose}>
-              Cancel
-            </Button>
-          </Modal.Footer>
         </Modal>
       </React.Fragment>
     );

--- a/src/renderer/components/SettingsModal/index.jsx
+++ b/src/renderer/components/SettingsModal/index.jsx
@@ -34,8 +34,10 @@ export default class SettingsModal extends React.Component {
 
   async componentDidMount() {
     const nWorkersOptions = [];
-    for (let i = -1; i <= this.props.nCPU; i++) {
-      nWorkersOptions.push(i);
+    nWorkersOptions.push([-1, 'Synchronous (-1)']);
+    nWorkersOptions.push([0, 'Threaded task management (0)']);
+    for (let i = 1; i <= this.props.nCPU; i++) {
+      nWorkersOptions.push([i, `${i} CPUs`]);
     }
     this.setState({
       nWorkersOptions: nWorkersOptions
@@ -83,7 +85,11 @@ export default class SettingsModal extends React.Component {
           />
         </Button>
 
-        <Modal show={this.state.show} onHide={this.handleClose}>
+        <Modal
+          className="settings-modal"
+          show={this.state.show}
+          onHide={this.handleClose}
+        >
           <Modal.Header>
             <Modal.Title>InVEST Settings</Modal.Title>
             <Button
@@ -97,8 +103,8 @@ export default class SettingsModal extends React.Component {
           </Modal.Header>
           <Modal.Body>
             <Form.Group as={Row}>
-              <Form.Label column sm="7" htmlFor="logging-select">Logging threshold</Form.Label>
-              <Col sm="5">
+              <Form.Label column sm="6" htmlFor="logging-select">Logging threshold</Form.Label>
+              <Col sm="6">
                 <Form.Control
                   id="logging-select"
                   as="select"
@@ -116,12 +122,12 @@ export default class SettingsModal extends React.Component {
               (this.state.nWorkersOptions)
                 ? (
                   <Form.Group as={Row}>
-                    <Col sm="7">
+                    <Col sm="6">
                       <Form.Label htmlFor="nworkers-select">
                         Taskgraph n_workers parameter
                       </Form.Label>
                     </Col>
-                    <Col sm="5">
+                    <Col sm="6">
                       <Form.Control
                         id="nworkers-select"
                         as="select"
@@ -131,7 +137,7 @@ export default class SettingsModal extends React.Component {
                         onChange={this.handleChange}
                       >
                         {this.state.nWorkersOptions.map(
-                          (opt) => <option value={opt} key={opt}>{opt}</option>
+                          (opt) => <option value={opt[0]}key={opt[0]}>{opt[1]}</option>
                         )}
                       </Form.Control>
                     </Col>
@@ -147,10 +153,13 @@ export default class SettingsModal extends React.Component {
                       </Accordion.Toggle>
                       <Accordion.Collapse eventKey="0" className="pr-1">
                         <ul>
-                          <li>-1: (recommended) synchronous mode</li>
-                          <li>0: single process with threaded task management</li>
+                          <li>synchronous task execution is most reliable</li>
                           <li>
-                            n: depending on the InVEST model, tasks may execute
+                            threaded task management: tasks execute only in the
+                            main process, using multiple threads.
+                          </li>
+                          <li>
+                            n CPUs: depending on the InVEST model, tasks may execute
                             in parallel using up to this many processes.
                           </li>
                         </ul>
@@ -188,7 +197,7 @@ export default class SettingsModal extends React.Component {
             >
               Clear Recent Jobs
             </Button>
-            <span><small>no invest workspaces will be deleted</small></span>
+            <span>no invest workspaces will be deleted</span>
           </Modal.Body>
         </Modal>
       </React.Fragment>

--- a/src/renderer/components/SettingsModal/index.jsx
+++ b/src/renderer/components/SettingsModal/index.jsx
@@ -145,13 +145,13 @@ export default class SettingsModal extends React.Component {
                         <BsChevronExpand className="mx-1" />
                         <span className="small"><u>more info</u></span>
                       </Accordion.Toggle>
-                      <Accordion.Collapse eventKey="0">
+                      <Accordion.Collapse eventKey="0" className="pr-1">
                         <ul>
                           <li>-1: (recommended) synchronous mode</li>
                           <li>0: single process with threaded task management</li>
                           <li>
-                            n CPUs: depending on the InVEST model, tasks may execute
-                            in parallel using this many processes.
+                            n: depending on the InVEST model, tasks may execute
+                            in parallel using up to this many processes.
                           </li>
                         </ul>
                       </Accordion.Collapse>
@@ -176,6 +176,7 @@ export default class SettingsModal extends React.Component {
             <Button
               variant="primary"
               onClick={this.switchToDownloadModal}
+              className="w-50"
             >
               Download Sample Data
             </Button>
@@ -183,10 +184,11 @@ export default class SettingsModal extends React.Component {
             <Button
               variant="secondary"
               onClick={this.props.clearJobsStorage}
+              className="mr-2 w-50"
             >
               Clear Recent Jobs
             </Button>
-            <div>(no invest workspaces will be deleted)</div>
+            <span><small>no invest workspaces will be deleted</small></span>
           </Modal.Body>
         </Modal>
       </React.Fragment>

--- a/src/renderer/components/SettingsModal/index.jsx
+++ b/src/renderer/components/SettingsModal/index.jsx
@@ -6,7 +6,7 @@ import Row from 'react-bootstrap/Row';
 import Form from 'react-bootstrap/Form';
 import Button from 'react-bootstrap/Button';
 import Modal from 'react-bootstrap/Modal';
-import { MdSettings } from 'react-icons/md';
+import { MdSettings, MdClose } from 'react-icons/md';
 
 import { getDefaultSettings } from './SettingsStorage';
 
@@ -84,11 +84,12 @@ export default class SettingsModal extends React.Component {
           <Modal.Header>
             <Modal.Title>InVEST Settings</Modal.Title>
             <Button
-              variant="secondary"
+              variant="secondary-outline"
               onClick={this.handleClose}
               className="float-right"
+              aria-label="close settings"
             >
-              Cancel
+              <MdClose />
             </Button>
           </Modal.Header>
           <Modal.Body>

--- a/src/renderer/components/SettingsModal/index.jsx
+++ b/src/renderer/components/SettingsModal/index.jsx
@@ -16,7 +16,7 @@ export default class SettingsModal extends React.Component {
     super(props);
     this.state = {
       show: false,
-      nWorkersOptions: [],
+      nWorkersOptions: null,
       logLevelOptions: ['DEBUG', 'INFO', 'WARNING', 'ERROR'],
     };
 
@@ -27,11 +27,9 @@ export default class SettingsModal extends React.Component {
     this.switchToDownloadModal = this.switchToDownloadModal.bind(this);
   }
 
-  componentDidMount() {
-    // const nCPU = ipcRenderer.invoke(ipcMainChannels.GET_N_CPUS, 'ping');
-    const nCPU = 12;
+  async componentDidMount() {
     const nWorkersOptions = [];
-    for (let i = -1; i <= nCPU; i++) {
+    for (let i = -1; i <= this.props.nCPU; i++) {
       nWorkersOptions.push(i);
     }
     this.setState({
@@ -109,27 +107,39 @@ export default class SettingsModal extends React.Component {
                 </Form.Control>
               </Col>
             </Form.Group>
-            <Form.Group as={Row}>
-              <Form.Label column sm="8" htmlFor="nworkers-select">
-                Taskgraph n_workers parameter
-                <br />
-                (must be an integer &gt;= -1)
-              </Form.Label>
-              <Col sm="4">
-                <Form.Control
-                  id="nworkers-select"
-                  as="select"
-                  name="nWorkers"
-                  type="text"
-                  value={this.props.investSettings.nWorkers}
-                  onChange={this.handleChange}
-                >
-                  {this.state.nWorkersOptions.map(
-                    (opt) => <option value={opt} key={opt}>{opt}</option>
-                  )}
-                </Form.Control>
-              </Col>
-            </Form.Group>
+            {
+              (this.state.nWorkersOptions)
+                ? (
+                  <Form.Group as={Row}>
+                    <Form.Label column sm="9" htmlFor="nworkers-select">
+                      Taskgraph n_workers parameter
+                      <ul>
+                        <li>-1: (recommended) synchronous mode</li>
+                        <li>0: single process with threaded task management</li>
+                        <li>
+                          n CPUs: depending on the InVEST model, tasks may execute
+                          in parallel using this many processes.
+                        </li>
+                      </ul>
+                    </Form.Label>
+                    <Col sm="3">
+                      <Form.Control
+                        id="nworkers-select"
+                        as="select"
+                        name="nWorkers"
+                        type="text"
+                        value={this.props.investSettings.nWorkers}
+                        onChange={this.handleChange}
+                      >
+                        {this.state.nWorkersOptions.map(
+                          (opt) => <option value={opt} key={opt}>{opt}</option>
+                        )}
+                      </Form.Control>
+                    </Col>
+                  </Form.Group>
+                )
+                : <div />
+            }
             <Button
               variant="secondary"
               onClick={this.handleReset}
@@ -167,4 +177,5 @@ SettingsModal.propTypes = {
     sampleDataDir: PropTypes.string,
   }),
   showDownloadModal: PropTypes.func,
+  nCPU: PropTypes.number
 };

--- a/src/renderer/components/SettingsModal/index.jsx
+++ b/src/renderer/components/SettingsModal/index.jsx
@@ -10,57 +10,38 @@ import { MdSettings } from 'react-icons/md';
 
 import { getDefaultSettings } from './SettingsStorage';
 
-/** Validate that n_workers is an acceptable value for Taskgraph.
- *
- * @param  {string} value - value for Taskgraph n_workers parameter.
- * @returns {boolean} - true if a valid value or false otherwise.
- *
- */
-function validateNWorkers(value) {
-  const nInt = parseInt(value);
-  return Number.isInteger(nInt) && nInt >= -1;
-}
-
 /** Render a dialog with a form for configuring global invest settings */
 export default class SettingsModal extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
       show: false,
-      localSettings: {
-        nWorkers: '',
-        loggingLevel: '',
-        sampleDataDir: null,
-      },
+      nWorkersOptions: [],
+      logLevelOptions: ['DEBUG', 'INFO', 'WARNING', 'ERROR'],
     };
 
     this.handleShow = this.handleShow.bind(this);
     this.handleClose = this.handleClose.bind(this);
     this.handleChange = this.handleChange.bind(this);
-    this.handleSubmit = this.handleSubmit.bind(this);
     this.handleReset = this.handleReset.bind(this);
     this.switchToDownloadModal = this.switchToDownloadModal.bind(this);
   }
 
   componentDidMount() {
+    // const nCPU = ipcRenderer.invoke(ipcMainChannels.GET_N_CPUS, 'ping');
+    const nCPU = 12;
+    const nWorkersOptions = [];
+    for (let i = -1; i <= nCPU; i++) {
+      nWorkersOptions.push(i);
+    }
     this.setState({
-      localSettings: this.props.investSettings
+      nWorkersOptions: nWorkersOptions
     });
   }
 
-  componentDidUpdate(prevProps) {
-    const { investSettings } = this.props;
-    if (JSON.stringify(investSettings) !== JSON.stringify(prevProps.investSettings)) {
-      this.setState({ localSettings: investSettings });
-    }
-  }
-
   handleClose() {
-    /** reset the local settings from the app's state because we closed w/o save */
-    const appSettings = Object.assign({}, this.props.investSettings)
     this.setState({
       show: false,
-      localSettings: appSettings,
     });
   }
 
@@ -68,31 +49,17 @@ export default class SettingsModal extends React.Component {
     this.setState({ show: true });
   }
 
-  handleSubmit(event) {
-    /** Handle a click on the "Save" button.
-     *
-     *  Updates the parent's state and persistent store.
-     */
-    event.preventDefault();
-    this.props.saveSettings(this.state.localSettings);
-    this.setState({ show: false });
-  }
-
   handleReset(event) {
     event.preventDefault();
     const resetSettings = getDefaultSettings();
-    this.setState({
-      localSettings: resetSettings,
-    });
+    this.props.saveSettings(resetSettings);
   }
 
   handleChange(event) {
-    const newSettings = { ...this.state.localSettings };
+    const newSettings = { ...this.props.investSettings };
     const { name, value } = event.currentTarget;
     newSettings[name] = value;
-    this.setState({
-      localSettings: newSettings,
-    });
+    this.props.saveSettings(newSettings);
   }
 
   switchToDownloadModal() {
@@ -101,13 +68,6 @@ export default class SettingsModal extends React.Component {
   }
 
   render() {
-    const logLevelOptions = [
-      'DEBUG', 'INFO', 'WARNING', 'ERROR'];
-
-    const nWorkersIsValid = validateNWorkers(
-      this.state.localSettings.nWorkers
-    );
-
     return (
       <React.Fragment>
         <Button
@@ -132,11 +92,11 @@ export default class SettingsModal extends React.Component {
                   id="logging-select"
                   as="select"
                   name="loggingLevel"
-                  value={this.state.localSettings.loggingLevel}
+                  value={this.props.investSettings.loggingLevel}
                   onChange={this.handleChange}
                 >
-                  {logLevelOptions.map(opt =>
-                    <option value={opt} key={opt}>{opt}</option>
+                  {this.state.logLevelOptions.map(
+                    (opt) => <option value={opt} key={opt}>{opt}</option>
                   )}
                 </Form.Control>
               </Col>
@@ -149,30 +109,26 @@ export default class SettingsModal extends React.Component {
               </Form.Label>
               <Col sm="4">
                 <Form.Control
-                  id="nworkers-text"
+                  id="nworkers-select"
+                  as="select"
                   name="nWorkers"
                   type="text"
-                  value={this.state.localSettings.nWorkers}
+                  value={this.props.investSettings.nWorkers}
                   onChange={this.handleChange}
-                  isInvalid={!nWorkersIsValid}
-                />
-              </Col>
-            </Form.Group>
-            <Form.Group as={Row}>
-              <Form.Label column sm="8">
-                Reset to Defaults
-              </Form.Label>
-              <Col sm="4">
-                <Button
-                  variant="secondary"
-                  onClick={this.handleReset}
-                  type="button"
-                  className="float-right"
                 >
-                  Reset
-                </Button>
+                  {this.state.nWorkersOptions.map(
+                    (opt) => <option value={opt} key={opt}>{opt}</option>
+                  )}
+                </Form.Control>
               </Col>
             </Form.Group>
+            <Button
+              variant="secondary"
+              onClick={this.handleReset}
+              type="button"
+            >
+              Reset to Defaults
+            </Button>
             <hr />
             <Button
               variant="primary"
@@ -181,34 +137,17 @@ export default class SettingsModal extends React.Component {
               Download Sample Data
             </Button>
             <hr />
-            <Form.Group as={Row}>
-              <Form.Label column sm="8">
-                Clear Recent Jobs Shortcuts
-                <br />
-                (no invest workspaces will be deleted)
-              </Form.Label>
-              <Col sm="4">
-                <Button
-                  variant="secondary"
-                  onClick={this.props.clearJobsStorage}
-                  className="float-right"
-                >
-                  Clear
-                </Button>
-              </Col>
-            </Form.Group>
+            <Button
+              variant="secondary"
+              onClick={this.props.clearJobsStorage}
+            >
+              Clear Recent Jobs
+            </Button>
+            <div>(no invest workspaces will be deleted)</div>
           </Modal.Body>
           <Modal.Footer>
             <Button variant="secondary" onClick={this.handleClose}>
               Cancel
-            </Button>
-            <Button
-              variant="primary"
-              onClick={this.handleSubmit}
-              type="submit"
-              disabled={!nWorkersIsValid}
-            >
-              Save Changes
             </Button>
           </Modal.Footer>
         </Modal>

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -7,14 +7,20 @@ import { ipcMainChannels } from '../main/ipcMainChannels';
 
 const logger = window.Workbench.getLogger(__filename.split('/').slice(-1)[0]);
 
-function render(isFirstRun) {
+async function render() {
+  const isFirstRun = await ipcRenderer.invoke(ipcMainChannels.IS_FIRST_RUN);
+  const nCPU = await ipcRenderer.invoke(ipcMainChannels.GET_N_CPUS);
   ReactDom.render(
-    <App isFirstRun={isFirstRun} />,
+    <App
+      isFirstRun={isFirstRun}
+      nCPU={nCPU}
+    />,
     document.getElementById('App')
   );
 }
 
-ipcRenderer.invoke(ipcMainChannels.IS_FIRST_RUN)
-  .then((response) => {
-    render(response);
-  });
+render();
+// ipcRenderer.invoke(ipcMainChannels.IS_FIRST_RUN)
+//   .then((response) => {
+//     render(response);
+//   });

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -20,7 +20,3 @@ async function render() {
 }
 
 render();
-// ipcRenderer.invoke(ipcMainChannels.IS_FIRST_RUN)
-//   .then((response) => {
-//     render(response);
-//   });

--- a/src/renderer/sampledata_registry.json
+++ b/src/renderer/sampledata_registry.json
@@ -1,138 +1,138 @@
 {
   "Annual Water Yield": {
     "filename": "Annual_Water_Yield.zip",
-    "url": "https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/3.9.2.post470+g11795c5c/data/Annual_Water_Yield.zip",
+    "url": "https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/3.9.2.post480+gc06f40d7/data/Annual_Water_Yield.zip",
     "filesize": "244430"
   },
   "Carbon Storage and Sequestration": {
     "filename": "Carbon.zip",
-    "url": "https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/3.9.2.post470+g11795c5c/data/Carbon.zip",
+    "url": "https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/3.9.2.post480+gc06f40d7/data/Carbon.zip",
     "filesize": "1900623"
   },
   "Coastal Blue Carbon": {
     "filename": "CoastalBlueCarbon.zip",
-    "url": "https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/3.9.2.post470+g11795c5c/data/CoastalBlueCarbon.zip",
+    "url": "https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/3.9.2.post480+gc06f40d7/data/CoastalBlueCarbon.zip",
     "filesize": "79665"
   },
   "Coastal Vulnerability": {
     "filename": "CoastalVulnerability.zip",
-    "url": "https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/3.9.2.post470+g11795c5c/data/CoastalVulnerability.zip",
+    "url": "https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/3.9.2.post480+gc06f40d7/data/CoastalVulnerability.zip",
     "filesize": "39930468",
     "labelSuffix": "(recommended to run model)"
   },
   "Crop Pollination": {
     "filename": "pollination.zip",
-    "url": "https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/3.9.2.post470+g11795c5c/data/pollination.zip",
+    "url": "https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/3.9.2.post480+gc06f40d7/data/pollination.zip",
     "filesize": "634514"
   },
   "Crop Production": {
     "filename": "CropProduction.zip",
-    "url": "https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/3.9.2.post470+g11795c5c/data/CropProduction.zip",
+    "url": "https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/3.9.2.post480+gc06f40d7/data/CropProduction.zip",
     "filesize": "58678907",
     "labelSuffix": "(required to run model)"
   },
   "DelineateIt": {
     "filename": "DelineateIt.zip",
-    "url": "https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/3.9.2.post470+g11795c5c/data/DelineateIt.zip",
+    "url": "https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/3.9.2.post480+gc06f40d7/data/DelineateIt.zip",
     "filesize": "529494"
   },
   "Finfish Aquaculture": {
     "filename": "Aquaculture.zip",
-    "url": "https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/3.9.2.post470+g11795c5c/data/Aquaculture.zip",
+    "url": "https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/3.9.2.post480+gc06f40d7/data/Aquaculture.zip",
     "filesize": "34618"
   },
   "Fisheries": {
     "filename": "Fisheries.zip",
-    "url": "https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/3.9.2.post470+g11795c5c/data/Fisheries.zip",
+    "url": "https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/3.9.2.post480+gc06f40d7/data/Fisheries.zip",
     "filesize": "274301"
   },
   "Forest Carbon Edge Effect": {
     "filename": "forest_carbon_edge_effect.zip",
-    "url": "https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/3.9.2.post470+g11795c5c/data/forest_carbon_edge_effect.zip",
+    "url": "https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/3.9.2.post480+gc06f40d7/data/forest_carbon_edge_effect.zip",
     "filesize": "1036547",
     "labelSuffix": "(required to run model)"
   },
   "GLOBIO": {
     "filename": "globio.zip",
-    "url": "https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/3.9.2.post470+g11795c5c/data/globio.zip",
+    "url": "https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/3.9.2.post480+gc06f40d7/data/globio.zip",
     "filesize": "2082836"
   },
   "Habitat Quality": {
     "filename": "HabitatQuality.zip",
-    "url": "https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/3.9.2.post470+g11795c5c/data/HabitatQuality.zip",
+    "url": "https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/3.9.2.post480+gc06f40d7/data/HabitatQuality.zip",
     "filesize": "1739986"
   },
   "Habitat Risk Assessment": {
     "filename": "HabitatRiskAssess.zip",
-    "url": "https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/3.9.2.post470+g11795c5c/data/HabitatRiskAssess.zip",
+    "url": "https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/3.9.2.post480+gc06f40d7/data/HabitatRiskAssess.zip",
     "filesize": "3268540"
   },
   "Nutrient Delivery Ratio": {
     "filename": "NDR.zip",
-    "url": "https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/3.9.2.post470+g11795c5c/data/NDR.zip",
+    "url": "https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/3.9.2.post480+gc06f40d7/data/NDR.zip",
     "filesize": "702024"
   },
   "RouteDEM": {
     "filename": "RouteDEM.zip",
-    "url": "https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/3.9.2.post470+g11795c5c/data/RouteDEM.zip",
+    "url": "https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/3.9.2.post480+gc06f40d7/data/RouteDEM.zip",
     "filesize": "526336"
   },
   "Scenario Generator: Proximity Based": {
     "filename": "scenario_proximity.zip",
-    "url": "https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/3.9.2.post470+g11795c5c/data/scenario_proximity.zip",
+    "url": "https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/3.9.2.post480+gc06f40d7/data/scenario_proximity.zip",
     "filesize": "927821"
   },
   "Seasonal Water Yield": {
     "filename": "Seasonal_Water_Yield.zip",
-    "url": "https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/3.9.2.post470+g11795c5c/data/Seasonal_Water_Yield.zip",
+    "url": "https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/3.9.2.post480+gc06f40d7/data/Seasonal_Water_Yield.zip",
     "filesize": "703708"
   },
   "Sediment Delivery Ratio": {
     "filename": "SDR.zip",
-    "url": "https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/3.9.2.post470+g11795c5c/data/SDR.zip",
+    "url": "https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/3.9.2.post480+gc06f40d7/data/SDR.zip",
     "filesize": "726317"
   },
   "Stormwater": {
     "filename": "storm_impact.zip",
-    "url": "https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/3.9.2.post470+g11795c5c/data/storm_impact.zip",
+    "url": "https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/3.9.2.post480+gc06f40d7/data/storm_impact.zip",
     "filesize": "436581"
   },
   "Unobstructed Views: Scenic Quality Provision": {
     "filename": "ScenicQuality.zip",
-    "url": "https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/3.9.2.post470+g11795c5c/data/ScenicQuality.zip",
+    "url": "https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/3.9.2.post480+gc06f40d7/data/ScenicQuality.zip",
     "filesize": "25073475"
   },
   "Urban Cooling": {
     "filename": "UrbanCoolingModel.zip",
-    "url": "https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/3.9.2.post470+g11795c5c/data/UrbanCoolingModel.zip",
+    "url": "https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/3.9.2.post480+gc06f40d7/data/UrbanCoolingModel.zip",
     "filesize": "1132530"
   },
   "Urban Flood Risk Mitigation": {
     "filename": "UrbanFloodMitigation.zip",
-    "url": "https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/3.9.2.post470+g11795c5c/data/UrbanFloodMitigation.zip",
+    "url": "https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/3.9.2.post480+gc06f40d7/data/UrbanFloodMitigation.zip",
     "filesize": "187926"
   },
   "Visitation: Recreation and Tourism": {
     "filename": "recreation.zip",
-    "url": "https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/3.9.2.post470+g11795c5c/data/recreation.zip",
+    "url": "https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/3.9.2.post480+gc06f40d7/data/recreation.zip",
     "filesize": "3695258"
   },
   "Wave Energy Production": {
     "filename": "WaveEnergy.zip",
-    "url": "https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/3.9.2.post470+g11795c5c/data/WaveEnergy.zip",
+    "url": "https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/3.9.2.post480+gc06f40d7/data/WaveEnergy.zip",
     "filesize": "77718614",
     "labelSuffix": "(required to run model)"
   },
   "Wind Energy Production": {
     "filename": "WindEnergy.zip",
-    "url": "https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/3.9.2.post470+g11795c5c/data/WindEnergy.zip",
+    "url": "https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/3.9.2.post480+gc06f40d7/data/WindEnergy.zip",
     "filesize": "5436801",
     "labelSuffix": "(required to run model)"
   },
   "Global DEM & Landmass Polygon": {
     "filename": "Base_Data.zip",
     "labelSuffix": "(required for Wind & Wave Energy)",
-    "url": "https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/3.9.2.post470+g11795c5c/data/Base_Data.zip",
+    "url": "https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/3.9.2.post480+gc06f40d7/data/Base_Data.zip",
     "filesize": "151372182"
   }
 }

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -470,3 +470,11 @@ input[type=text]::placeholder {
 	height: 80vh;
 	overflow-y: auto;
 }
+
+/* Settings Modal */
+.settings-modal .modal-dialog {
+	/*Hardcoding prevents dynamic resizing, which is convenient.
+	And it is okay because we set the minimum electron window width
+	at 800px when we create it.*/
+	max-width: 600px;
+}

--- a/tests/main/main.test.js
+++ b/tests/main/main.test.js
@@ -175,6 +175,7 @@ describe('createWindow', () => {
       ipcMainChannels.SHOW_OPEN_DIALOG,
       ipcMainChannels.SHOW_SAVE_DIALOG,
       ipcMainChannels.IS_FIRST_RUN,
+      ipcMainChannels.GET_N_CPUS,
     ];
     const expectedOnChannels = [
       ipcMainChannels.DOWNLOAD_URL,

--- a/tests/renderer/app.test.js
+++ b/tests/renderer/app.test.js
@@ -355,7 +355,7 @@ describe('Display recently executed InVEST jobs on Home tab', () => {
       });
     });
     fireEvent.click(getByRole('button', { name: 'settings' }));
-    fireEvent.click(getByText('Clear'));
+    fireEvent.click(getByText('Clear Recent Jobs'));
     const node = await findByText(/button to setup a model/);
     expect(node).toBeInTheDocument();
   });
@@ -495,7 +495,7 @@ describe('InVEST global settings: dialog interactions', () => {
     });
 
     // Test Reset sets values to default
-    userEvent.click(getByText('Reset'));
+    userEvent.click(getByText('Reset to Defaults'));
     await waitFor(() => {
       expect(nWorkersInput).toHaveValue(defaultSettings.nWorkers);
       expect(loggingInput).toHaveValue(defaultSettings.loggingLevel);

--- a/tests/renderer/app.test.js
+++ b/tests/renderer/app.test.js
@@ -373,7 +373,7 @@ describe('InVEST global settings: dialog interactions', () => {
     jest.resetAllMocks();
   });
 
-  test('Invest settings: change & Cancel', async () => {
+  test('Invest settings save on change', async () => {
     const nWorkers = '2';
     const loggingLevel = 'DEBUG';
 
@@ -387,56 +387,15 @@ describe('InVEST global settings: dialog interactions', () => {
     const nWorkersInput = getByLabelText(nWorkersLabelText, { exact: false });
     const loggingInput = getByLabelText(loggingLabelText, { exact: false });
 
-    // Test that the default values are loaded.
-    await waitFor(() => {
-      expect(nWorkersInput).toHaveValue('-1');
-      expect(loggingInput).toHaveValue('INFO');
-    });
-
-    // Change the input values
-    userEvent.clear(nWorkersInput);
-    userEvent.type(nWorkersInput, nWorkers);
+    userEvent.selectOptions(nWorkersInput, [nWorkers]);
     userEvent.selectOptions(loggingInput, [loggingLevel]);
     await waitFor(() => {
       expect(nWorkersInput).toHaveValue(nWorkers);
       expect(loggingInput).toHaveValue(loggingLevel);
     });
-    // Cancel instead of save, so expect defaults again
     userEvent.click(getByText('Cancel'));
-    userEvent.click(await findByRole('button', { name: 'settings' }));
-    await waitFor(() => {
-      expect(nWorkersInput).toHaveValue('-1');
-      expect(loggingInput).toHaveValue('INFO');
-    });
 
-    // Check values in the settings store have not changed
-    expect(await getSettingsValue('nWorkers')).toBe('-1');
-    expect(await getSettingsValue('loggingLevel')).toBe('INFO');
-  });
-
-  test('Invest settings: change & Save', async () => {
-    const nWorkers = '2';
-    const loggingLevel = 'DEBUG';
-
-    const {
-      getByText, getByLabelText, findByRole
-    } = render(
-      <App />
-    );
-
-    userEvent.click(await findByRole('button', { name: 'settings' }));
-    const nWorkersInput = getByLabelText(nWorkersLabelText, { exact: false });
-    const loggingInput = getByLabelText(loggingLabelText, { exact: false });
-
-    userEvent.clear(nWorkersInput);
-    userEvent.type(nWorkersInput, nWorkers);
-    userEvent.selectOptions(loggingInput, [loggingLevel]);
-    await waitFor(() => {
-      expect(nWorkersInput).toHaveValue(nWorkers);
-      expect(loggingInput).toHaveValue(loggingLevel);
-    });
-    userEvent.click(getByText('Save Changes'));
-    // Check values in the settings store were saved
+    // Check values were saved in app and in store
     userEvent.click(await findByRole('button', { name: 'settings' }));
     await waitFor(() => {
       expect(nWorkersInput).toHaveValue(nWorkers);
@@ -444,26 +403,6 @@ describe('InVEST global settings: dialog interactions', () => {
     });
     expect(await getSettingsValue('nWorkers')).toBe(nWorkers);
     expect(await getSettingsValue('loggingLevel')).toBe(loggingLevel);
-  });
-
-  test('Invest settings: invalid nWorkers value', async () => {
-    const badValue = 'a';
-
-    const {
-      getByText, getByLabelText, findByRole
-    } = render(
-      <App />
-    );
-
-    // Change n_workers to bad value -- expect invalid signal
-    userEvent.click(await findByRole('button', { name: 'settings' }));
-    const nWorkersInput = getByLabelText(nWorkersLabelText, { exact: false });
-    userEvent.clear(nWorkersInput);
-    userEvent.type(nWorkersInput, badValue);
-    await waitFor(() => {
-      expect(nWorkersInput.classList.contains('is-invalid')).toBeTruthy();
-      expect(getByText('Save Changes')).toBeDisabled();
-    });
   });
 
   test('Load invest settings from storage and test Reset', async () => {
@@ -499,14 +438,6 @@ describe('InVEST global settings: dialog interactions', () => {
     await waitFor(() => {
       expect(nWorkersInput).toHaveValue(defaultSettings.nWorkers);
       expect(loggingInput).toHaveValue(defaultSettings.loggingLevel);
-    });
-
-    // Expect reset values to not have been saved when cancelling
-    userEvent.click(getByText('Cancel'));
-    userEvent.click(await findByRole('button', { name: 'settings' }));
-    await waitFor(() => {
-      expect(nWorkersInput).toHaveValue(expectedSettings.nWorkers);
-      expect(loggingInput).toHaveValue(expectedSettings.loggingLevel);
     });
   });
 

--- a/tests/renderer/app.test.js
+++ b/tests/renderer/app.test.js
@@ -374,11 +374,11 @@ describe('InVEST global settings: dialog interactions', () => {
   });
 
   test('Invest settings save on change', async () => {
-    const nWorkers = '2';
+    const nWorkers = '0';
     const loggingLevel = 'DEBUG';
 
     const {
-      getByText, getByLabelText, findByRole
+      getByRole, getByLabelText, findByRole
     } = render(
       <App />
     );
@@ -393,7 +393,7 @@ describe('InVEST global settings: dialog interactions', () => {
       expect(nWorkersInput).toHaveValue(nWorkers);
       expect(loggingInput).toHaveValue(loggingLevel);
     });
-    userEvent.click(getByText('Cancel'));
+    userEvent.click(getByRole('button', { name: 'close settings' }));
 
     // Check values were saved in app and in store
     userEvent.click(await findByRole('button', { name: 'settings' }));
@@ -411,7 +411,7 @@ describe('InVEST global settings: dialog interactions', () => {
       loggingLevel: 'INFO',
     };
     const expectedSettings = {
-      nWorkers: '3',
+      nWorkers: '0',
       loggingLevel: 'ERROR',
     };
 

--- a/tests/renderer/app.test.js
+++ b/tests/renderer/app.test.js
@@ -374,11 +374,12 @@ describe('InVEST global settings: dialog interactions', () => {
   });
 
   test('Invest settings save on change', async () => {
-    const nWorkers = '0';
+    const nWorkersLabel = 'Threaded task management (0)';
+    const nWorkersValue = '0';
     const loggingLevel = 'DEBUG';
 
     const {
-      getByRole, getByLabelText, findByRole
+      getByText, getByRole, getByLabelText, findByRole
     } = render(
       <App />
     );
@@ -387,10 +388,10 @@ describe('InVEST global settings: dialog interactions', () => {
     const nWorkersInput = getByLabelText(nWorkersLabelText, { exact: false });
     const loggingInput = getByLabelText(loggingLabelText, { exact: false });
 
-    userEvent.selectOptions(nWorkersInput, [nWorkers]);
+    userEvent.selectOptions(nWorkersInput, [getByText(nWorkersLabel)]);
     userEvent.selectOptions(loggingInput, [loggingLevel]);
     await waitFor(() => {
-      expect(nWorkersInput).toHaveValue(nWorkers);
+      expect(nWorkersInput).toHaveValue(nWorkersValue);
       expect(loggingInput).toHaveValue(loggingLevel);
     });
     userEvent.click(getByRole('button', { name: 'close settings' }));
@@ -398,10 +399,10 @@ describe('InVEST global settings: dialog interactions', () => {
     // Check values were saved in app and in store
     userEvent.click(await findByRole('button', { name: 'settings' }));
     await waitFor(() => {
-      expect(nWorkersInput).toHaveValue(nWorkers);
+      expect(nWorkersInput).toHaveValue(nWorkersValue);
       expect(loggingInput).toHaveValue(loggingLevel);
     });
-    expect(await getSettingsValue('nWorkers')).toBe(nWorkers);
+    expect(await getSettingsValue('nWorkers')).toBe(nWorkersValue);
     expect(await getSettingsValue('loggingLevel')).toBe(loggingLevel);
   });
 


### PR DESCRIPTION
Fixes #200 

In addition to the issues mentioned in the issue, this PR also switches the `n_workers` input field to a dropdown menu populated with numbers from -1 to the number of available CPUs. That data comes from NodeJS and is sent to the renderer at app startup. That removes the need to validate that input field.

I also added some expandable/collapsible helptext for that parameter, similar to what we have in the Qt UI. 

![settings_ui](https://user-images.githubusercontent.com/4071255/142479397-2b89bcb8-43a9-43e6-b135-f3d6b586d0a0.PNG)
