### PR TITLE
Alert width should not expand to fit it's content

### DIFF
--- a/src/renderer/components/InvestTab/ModelStatusAlert/index.jsx
+++ b/src/renderer/components/InvestTab/ModelStatusAlert/index.jsx
@@ -34,7 +34,10 @@ export default function ModelStatusAlert(props) {
   }
   if (props.status === 'error') {
     return (
-      <Alert variant="danger">
+      <Alert
+        className="text-break"
+        variant="danger"
+      >
         {props.finalTraceback}
         {WorkspaceButton}
       </Alert>


### PR DESCRIPTION
Fixes #168 for the edge case of very-long-text-strings-with-no-whitespace-on-which-to-break-lines.

Before image in the issue. After image:
![Capture](https://user-images.githubusercontent.com/4071255/145876146-63eb2428-6f36-4ca2-a9ad-7df618c52639.PNG)
