### PR TITLE
Bugfix/212 invest log regex

### DIFF
--- a/src/main/investLogMarkup.js
+++ b/src/main/investLogMarkup.js
@@ -28,5 +28,5 @@ export default function markupMessage(message, pyModuleName) {
       return sanitizeHtml(markup, allowedHtml);
     }
   }
-  return sanitizeHtml(message, allowedHtml);
+  return sanitizeHtml(message);
 }

--- a/src/main/investLogMarkup.js
+++ b/src/main/investLogMarkup.js
@@ -1,0 +1,32 @@
+import sanitizeHtml from 'sanitize-html';
+
+/**
+ * Encapsulate text in html, assigning class based on text content.
+ *
+ * @param  {string} message - from a python logger
+ * @param  {string} pyModuleName - e.g. 'natcap.invest.carbon'
+ * @returns {string} - sanitized html
+ */
+export default function markupMessage(message, pyModuleName) {
+  const escapedPyModuleName = pyModuleName.replace(/\./g, '\\.');
+  const patterns = {
+    'invest-log-error': /(ERROR|CRITICAL)/,
+    'invest-log-primary-warning': new RegExp(`${escapedPyModuleName}.*WARNING`),
+    'invest-log-primary': new RegExp(escapedPyModuleName)
+  };
+
+  const logTextTag = 'span';
+  const allowedHtml = {
+    allowedTags: [logTextTag],
+    allowedAttributes: { [logTextTag]: ['class'] },
+  };
+
+  // eslint-disable-next-line
+  for (const [cls, pattern] of Object.entries(patterns)) {
+    if (pattern.test(message)) {
+      const markup = `<${logTextTag} class="${cls}">${message}</${logTextTag}>`;
+      return sanitizeHtml(markup, allowedHtml);
+    }
+  }
+  return sanitizeHtml(message, allowedHtml);
+}

--- a/src/main/setupInvestHandlers.js
+++ b/src/main/setupInvestHandlers.js
@@ -154,7 +154,7 @@ export function setupInvestRunHandlers(investExe) {
 
 export function setupInvestLogReaderHandler() {
   ipcMain.on(ipcMainChannels.INVEST_READ_LOG,
-    (event, logfile, pyModuleName, channel) => {
+    (event, logfile, channel) => {
       const fileStream = fs.createReadStream(logfile);
       fileStream.on('error', (err) => {
         logger.error(err);

--- a/src/main/setupInvestHandlers.js
+++ b/src/main/setupInvestHandlers.js
@@ -5,12 +5,12 @@ import { spawn, exec } from 'child_process';
 
 import { app, ipcMain } from 'electron';
 import fetch from 'node-fetch';
-import sanitizeHtml from 'sanitize-html';
 
 import { getLogger } from '../logger';
 import { ipcMainChannels } from './ipcMainChannels';
 import ELECTRON_DEV_MODE from './isDevMode';
 import investUsageLogger from './investUsageLogger';
+import markupMessage from './investLogMarkup';
 
 const logger = getLogger(__filename.split('/').slice(-1)[0]);
 
@@ -23,49 +23,6 @@ const LOGLEVELMAP = {
 };
 const TEMP_DIR = path.join(app.getPath('userData'), 'tmp');
 const HOSTNAME = 'http://localhost';
-
-// const LOG_TEXT_TAG = 'span';
-// const ALLOWED_HTML_OPTIONS = {
-//   allowedTags: [LOG_TEXT_TAG],
-//   allowedAttributes: { [LOG_TEXT_TAG]: ['class'] },
-// };
-
-// const LOG_ERROR_REGEX = /(ERROR|CRITICAL)/;
-// export const LOG_PATTERNS = {
-//   'invest-log-error': LOG_ERROR_REGEX,
-//   'invest-log-primary-warning': null,
-//   'invest-log-primary': null,
-// };
-/**
- * Encapsulate text in html, assigning class based on text content.
- *
- * @param  {string} message - from a python logger
- * @param  {string} pyModuleName - e.g. 'natcap.invest.carbon'
- * @returns {string} - sanitized html
- */
-export function markupMessage(message, pyModuleName) {
-  const escapedPyModuleName = pyModuleName.replace(/\./g, '\\.');
-  const patterns = {
-    'invest-log-error': /(ERROR|CRITICAL)/,
-    'invest-log-primary-warning': new RegExp(`${escapedPyModuleName}.*WARNING`),
-    'invest-log-primary': new RegExp(escapedPyModuleName)
-  };
-
-  const LOG_TEXT_TAG = 'span';
-  const ALLOWED_HTML_OPTIONS = {
-    allowedTags: [LOG_TEXT_TAG],
-    allowedAttributes: { [LOG_TEXT_TAG]: ['class'] },
-  };
-
-  // eslint-disable-next-line
-  for (const [cls, pattern] of Object.entries(patterns)) {
-    if (pattern.test(message)) {
-      const markup = `<${LOG_TEXT_TAG} class="${cls}">${message}</${LOG_TEXT_TAG}>`;
-      return sanitizeHtml(markup, ALLOWED_HTML_OPTIONS);
-    }
-  }
-  return sanitizeHtml(message, ALLOWED_HTML_OPTIONS);
-}
 
 export function setupInvestRunHandlers(investExe) {
   const runningJobs = {};

--- a/src/main/setupInvestHandlers.js
+++ b/src/main/setupInvestHandlers.js
@@ -24,32 +24,44 @@ const LOGLEVELMAP = {
 const TEMP_DIR = path.join(app.getPath('userData'), 'tmp');
 const HOSTNAME = 'http://localhost';
 
-const LOG_TEXT_TAG = 'span';
-const ALLOWED_HTML_OPTIONS = {
-  allowedTags: [LOG_TEXT_TAG],
-  allowedAttributes: { [LOG_TEXT_TAG]: ['class'] },
-};
-const LOG_ERROR_REGEX = /(Traceback)|(([A-Z]{1}[a-z]*){1,}Error)|(ERROR)/;
-export const LOG_PATTERNS = {
-  'invest-log-error': LOG_ERROR_REGEX,
-  'invest-log-primary': null,
-};
+// const LOG_TEXT_TAG = 'span';
+// const ALLOWED_HTML_OPTIONS = {
+//   allowedTags: [LOG_TEXT_TAG],
+//   allowedAttributes: { [LOG_TEXT_TAG]: ['class'] },
+// };
+
+// const LOG_ERROR_REGEX = /(ERROR|CRITICAL)/;
+// export const LOG_PATTERNS = {
+//   'invest-log-error': LOG_ERROR_REGEX,
+//   'invest-log-primary-warning': null,
+//   'invest-log-primary': null,
+// };
 /**
  * Encapsulate text in html, assigning class based on text content.
  *
- * @param  {string} message - plaintext string
- * @param  {object} patterns - of shape {string: RegExp}
+ * @param  {string} message - from a python logger
+ * @param  {string} pyModuleName - e.g. 'natcap.invest.carbon'
  * @returns {string} - sanitized html
  */
-export function markupMessage(message, patterns) {
+export function markupMessage(message, pyModuleName) {
+  const escapedPyModuleName = pyModuleName.replace(/\./g, '\\.');
+  const patterns = {
+    'invest-log-error': /(ERROR|CRITICAL)/,
+    'invest-log-primary-warning': new RegExp(`${escapedPyModuleName}.*WARNING`),
+    'invest-log-primary': new RegExp(escapedPyModuleName)
+  };
+
+  const LOG_TEXT_TAG = 'span';
+  const ALLOWED_HTML_OPTIONS = {
+    allowedTags: [LOG_TEXT_TAG],
+    allowedAttributes: { [LOG_TEXT_TAG]: ['class'] },
+  };
+
   // eslint-disable-next-line
   for (const [cls, pattern] of Object.entries(patterns)) {
-    // in case we somehow don't have a RegExp as the pattern
-    if (pattern && typeof pattern.test === 'function') {
-      if (pattern.test(message)) {
-        const markup = `<${LOG_TEXT_TAG} class="${cls}">${message}</${LOG_TEXT_TAG}>`;
-        return sanitizeHtml(markup, ALLOWED_HTML_OPTIONS);
-      }
+    if (pattern.test(message)) {
+      const markup = `<${LOG_TEXT_TAG} class="${cls}">${message}</${LOG_TEXT_TAG}>`;
+      return sanitizeHtml(markup, ALLOWED_HTML_OPTIONS);
     }
   }
   return sanitizeHtml(message, ALLOWED_HTML_OPTIONS);
@@ -76,8 +88,6 @@ export function setupInvestRunHandlers(investExe) {
     let investRun;
     let investStarted = false;
     let investStdErr = '';
-    const logPatterns = { ...LOG_PATTERNS };
-    logPatterns['invest-log-primary'] = new RegExp(pyModuleName);
     const usageLogger = investUsageLogger();
 
     // Write a temporary datastack json for passing to invest CLI
@@ -150,7 +160,7 @@ export function setupInvestRunHandlers(investExe) {
       // only be one logger message at a time.
       event.reply(
         `invest-stdout-${jobID}`,
-        markupMessage(`${data}`, logPatterns)
+        markupMessage(`${data}`, pyModuleName)
       );
     };
     investRun.stdout.on('data', stdOutCallback);

--- a/src/renderer/components/InvestTab/index.jsx
+++ b/src/renderer/components/InvestTab/index.jsx
@@ -304,7 +304,6 @@ export default class InvestTab extends React.Component {
                   logfile={logfile}
                   executeClicked={executeClicked}
                   jobID={jobID}
-                  pyModuleName={modelSpec.pyname}
                 />
               </TabPane>
             </TabContent>

--- a/src/renderer/components/LogTab/index.jsx
+++ b/src/renderer/components/LogTab/index.jsx
@@ -65,7 +65,6 @@ export default class LogTab extends React.Component {
       ipcRenderer.send(
         ipcMainChannels.INVEST_READ_LOG,
         logfile,
-        this.props.pyModuleName,
         jobID,
       );
     }
@@ -98,5 +97,4 @@ LogTab.propTypes = {
   logfile: PropTypes.string,
   executeClicked: PropTypes.bool.isRequired,
   jobID: PropTypes.string.isRequired,
-  pyModuleName: PropTypes.string.isRequired,
 };

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -456,6 +456,10 @@ input[type=text]::placeholder {
 	font-weight: bold;
 }
 
+#log-text .invest-log-primary-warning {
+	color: #f13232;
+}
+
 #log-text .invest-log-error {
 	color: #f13232;
 	font-weight: bold;

--- a/tests/renderer/logtab.test.js
+++ b/tests/renderer/logtab.test.js
@@ -14,7 +14,6 @@ import LogTab from '../../src/renderer/components/LogTab';
 import {
   setupInvestLogReaderHandler,
   markupMessage,
-  LOG_PATTERNS,
 } from '../../src/main/setupInvestHandlers';
 import { removeIpcMainListeners } from '../../src/main/main';
 
@@ -30,14 +29,14 @@ function renderLogTab(logfilePath, primaryPythonLogger) {
   return utils;
 }
 
-const WORKSPACE = fs.mkdtempSync(path.join(os.tmpdir(), 'data-'));
-function makeLogFile(text) {
-  const logfilePath = path.join(WORKSPACE, 'logfile.txt');
-  fs.writeFileSync(logfilePath, text);
-  return logfilePath;
-}
-
 describe('LogTab displays log from a file', () => {
+  const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'data-'));
+  function makeLogFile(text) {
+    const logfilePath = path.join(workspace, 'logfile.txt');
+    fs.writeFileSync(logfilePath, text);
+    return logfilePath;
+  }
+
   const uniqueText = 'utils.prepare_workspace';
   const primaryPythonLogger = 'natcap.invest.annual_water_yield';
 
@@ -80,7 +79,7 @@ ValueError: Values in the LULC raster were found that are not represented under 
 
   afterAll(() => {
     removeIpcMainListeners();
-    fs.rmSync(WORKSPACE, { recursive: true, force: true });
+    fs.rmSync(workspace, { recursive: true, force: true });
   });
 
   test('Text in logfile is rendered', async () => {
@@ -119,46 +118,19 @@ ValueError: Values in the LULC raster were found that are not represented under 
       logfilePath, primaryPythonLogger
     );
 
-    // The start of a python traceback
-    let errorMessages = await findAllByText(/Traceback/);
-    errorMessages.forEach((msg) => {
-      expect(msg).toHaveClass('invest-log-error');
-    });
-
-    // The indented contents of a python traceback
-    errorMessages = await findAllByText(/File site-packages/);
-    errorMessages.forEach((msg) => {
-      expect(msg).toHaveClass('invest-log-error');
-    });
-
     // an ERROR-level message from a python logger
     errorMessages = await findAllByText(/ERROR Something went wrong/);
     errorMessages.forEach((msg) => {
       expect(msg).toHaveClass('invest-log-error');
     });
-
-    // a message from a custom python exception class
-    errorMessages = await findAllByText(/ReclassificationMissingValuesError/);
-    errorMessages.forEach((msg) => {
-      expect(msg).toHaveClass('invest-log-error');
-    });
-
-    // a message from a built-in python exception class
-    errorMessages = await findAllByText(/ValueError:/);
-    errorMessages.forEach((msg) => {
-      expect(msg).toHaveClass('invest-log-error');
-    });
-  });
 });
 
 describe('Unit tests for invest logger message markup', () => {
   const pyModuleName = 'natcap.invest.carbon';
 
   test('Message from the invest model gets primary class attribute', () => {
-    const logPatterns = { ...LOG_PATTERNS };
-    logPatterns['invest-log-primary'] = new RegExp(pyModuleName);
     const message = `2021-01-15 07:14:37,148 (${pyModuleName}) ... INFO`;
-    const markup = markupMessage(message, logPatterns);
+    const markup = markupMessage(message, pyModuleName);
     // Rendering and using DOM matchers adds confidence that we have valid html
     // Render the same way we do in LogDisplay component:
     const { getByText } = render(
@@ -167,15 +139,20 @@ describe('Unit tests for invest logger message markup', () => {
     expect(getByText(message)).toHaveClass('invest-log-primary');
   });
 
-  test.each([
-    '... (osgeo.gdal) ... ERROR',
-    '... (foo.bar) ... SomeCustomError',
-    `... (${pyModuleName}) ... ValueError`,
-    'Traceback...',
-  ])('Message "%s" gets error class attribute', (message) => {
-    const logPatterns = { ...LOG_PATTERNS };
-    logPatterns['invest-log-primary'] = new RegExp(pyModuleName);
-    const markup = markupMessage(message, logPatterns);
+  test('Warning from the invest model gets primary-warning class attribute', () => {
+    const message = `2021-01-15 07:14:37,148 (${pyModuleName}) ... WARNING`;
+    const markup = markupMessage(message, pyModuleName);
+    // Rendering and using DOM matchers adds confidence that we have valid html
+    // Render the same way we do in LogDisplay component:
+    const { getByText } = render(
+      <div dangerouslySetInnerHTML={{ __html: markup }} />
+    );
+    expect(getByText(message)).toHaveClass('invest-log-primary-warning');
+  });
+
+  test('Error from any any module gets error class attribute', () => {
+    const message = '... (osgeo.gdal) ... ERROR';
+    const markup = markupMessage(message, pyModuleName);
     const { getByText } = render(
       <div dangerouslySetInnerHTML={{ __html: markup }} />
     );
@@ -183,20 +160,8 @@ describe('Unit tests for invest logger message markup', () => {
   });
 
   test('All other messages do not get markup', () => {
-    const logPatterns = { ...LOG_PATTERNS };
-    logPatterns['invest-log-primary'] = new RegExp(pyModuleName);
     const message = '2021-01-15 07:14:37,148 (foo.bar) ... INFO';
-    const markup = markupMessage(message, logPatterns);
-    const { getByText } = render(
-      <div dangerouslySetInnerHTML={{ __html: markup }} />
-    );
-    expect(getByText(message)).not.toHaveClass();
-  });
-
-  test('Messages pass through if pattern is not a RegExp', () => {
-    const message = `2021-01-15 07:14:37,148 (${pyModuleName}) ... INFO`;
-    expect(LOG_PATTERNS['invest-log-primary']).toBeNull();
-    const markup = markupMessage(message, LOG_PATTERNS);
+    const markup = markupMessage(message, pyModuleName);
     const { getByText } = render(
       <div dangerouslySetInnerHTML={{ __html: markup }} />
     );

--- a/tests/renderer/logtab.test.js
+++ b/tests/renderer/logtab.test.js
@@ -11,10 +11,8 @@ import { render } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 import LogTab from '../../src/renderer/components/LogTab';
-import {
-  setupInvestLogReaderHandler,
-  markupMessage,
-} from '../../src/main/setupInvestHandlers';
+import { setupInvestLogReaderHandler } from '../../src/main/setupInvestHandlers';
+import markupMessage from '../../src/main/investLogMarkup';
 import { removeIpcMainListeners } from '../../src/main/main';
 
 function renderLogTab(logfilePath, primaryPythonLogger) {
@@ -39,7 +37,6 @@ describe('LogTab displays log from a file', () => {
 
   const uniqueText = 'utils.prepare_workspace';
   const primaryPythonLogger = 'natcap.invest.annual_water_yield';
-
   const logText = `
 2021-01-15 07:14:37,147 (natcap.invest.utils) ${uniqueText}(124) INFO Writing log ...
 2021-01-15 07:14:37,147 (__main__) cli.main(521) Level 100 Starting model with parameters: 
@@ -123,6 +120,7 @@ ValueError: Values in the LULC raster were found that are not represented under 
     errorMessages.forEach((msg) => {
       expect(msg).toHaveClass('invest-log-error');
     });
+  });
 });
 
 describe('Unit tests for invest logger message markup', () => {

--- a/tests/renderer/logtab.test.js
+++ b/tests/renderer/logtab.test.js
@@ -15,13 +15,12 @@ import { setupInvestLogReaderHandler } from '../../src/main/setupInvestHandlers'
 import markupMessage from '../../src/main/investLogMarkup';
 import { removeIpcMainListeners } from '../../src/main/main';
 
-function renderLogTab(logfilePath, primaryPythonLogger) {
+function renderLogTab(logfilePath) {
   const { ...utils } = render(
     <LogTab
       executeClicked={false}
       jobID="foo"
       logfile={logfilePath}
-      pyModuleName={primaryPythonLogger}
     />
   );
   return utils;
@@ -80,18 +79,14 @@ ValueError: Values in the LULC raster were found that are not represented under 
   });
 
   test('Text in logfile is rendered', async () => {
-    const { findByText } = renderLogTab(
-      logfilePath, primaryPythonLogger
-    );
+    const { findByText } = renderLogTab(logfilePath);
 
     const log = await findByText(new RegExp(uniqueText));
     expect(log).toBeInTheDocument();
   });
 
   test('message from non-primary invest logger is plain', async () => {
-    const { findByText } = renderLogTab(
-      logfilePath, primaryPythonLogger
-    );
+    const { findByText } = renderLogTab(logfilePath);
 
     const log = await findByText(new RegExp(uniqueText));
     expect(log).not.toHaveClass();
@@ -99,9 +94,7 @@ ValueError: Values in the LULC raster were found that are not represented under 
 
   // Skip because https://github.com/natcap/invest-workbench/issues/169
   test.skip('messages from primary invest logger are highlighted', async () => {
-    const { findAllByText } = renderLogTab(
-      logfilePath, primaryPythonLogger
-    );
+    const { findAllByText } = renderLogTab(logfilePath);
 
     const messages = await findAllByText(new RegExp(primaryPythonLogger));
     messages.forEach((msg) => {
@@ -111,12 +104,10 @@ ValueError: Values in the LULC raster were found that are not represented under 
 
   // Skip because https://github.com/natcap/invest-workbench/issues/169
   test.skip('error messages are highlighted', async () => {
-    const { findAllByText } = renderLogTab(
-      logfilePath, primaryPythonLogger
-    );
+    const { findAllByText } = renderLogTab(logfilePath);
 
     // an ERROR-level message from a python logger
-    errorMessages = await findAllByText(/ERROR Something went wrong/);
+    const errorMessages = await findAllByText(/ERROR Something went wrong/);
     errorMessages.forEach((msg) => {
       expect(msg).toHaveClass('invest-log-error');
     });


### PR DESCRIPTION
This PR fixes #212 .

It also generally simplifies and cleans up this feature by moving it to a separate module. Also, when this feature was first developed, we were parsing invest logs line-by-line whereas now we parse them message-by-message, and that makes it much easier (simpler regex) to assign the correct markup to multi-line messages such as Tracebacks.

Now the markup is as follows:
* `DEBUG|INFO` messages from the invest model are bold
* `WARNING` messages from the invest model are red (not bold)
* `ERROR|CRITICAL` messages from any module are red & bold

**BEFORE:**
![logging_before1](https://user-images.githubusercontent.com/4071255/148786400-e84e8c2c-0710-4cfe-a427-378feab3c365.png)
the shapely warnings are mistakenly bold because they happen to include the string `natcap/invest/coastal_vulnerability`

![logging_before2](https://user-images.githubusercontent.com/4071255/148786405-35293d94-c7a9-43a7-805d-cb640b6884f6.png)
And this one is incorrectly bold red because it includes the string `AttributeError`.

**AFTER:**
![logging_after](https://user-images.githubusercontent.com/4071255/148786809-01f5b178-4fdf-412c-b145-d26f3e5699c6.png)
shapely messages are plain. `WARNINGS` from the invest model are elevated to red. 