### PR TITLE
optimize calls to invest validation

### DIFF
--- a/src/renderer/components/SetupTab/ArgInput/index.jsx
+++ b/src/renderer/components/SetupTab/ArgInput/index.jsx
@@ -115,6 +115,7 @@ export default class ArgInput extends React.PureComponent {
       enabled,
       handleBoolChange,
       handleChange,
+      handleFocus,
       inputDropHandler,
       isValid,
       selectFile,
@@ -181,7 +182,7 @@ export default class ArgInput extends React.PureComponent {
                   placeholder={placeholderText}
                   value={value || ''} // empty string is handled better than `undefined`
                   onChange={handleChange}
-                  onFocus={handleChange}
+                  onFocus={handleFocus}
                   isValid={enabled && touched && isValid}
                   isInvalid={enabled && validationMessage}
                   disabled={!enabled}
@@ -332,6 +333,7 @@ ArgInput.propTypes = {
   touched: PropTypes.bool,
   isValid: PropTypes.bool,
   validationMessage: PropTypes.string,
+  handleFocus: PropTypes.func.isRequired,
   handleChange: PropTypes.func.isRequired,
   handleBoolChange: PropTypes.func.isRequired,
   selectFile: PropTypes.func.isRequired,

--- a/src/renderer/components/SetupTab/ArgsForm/index.jsx
+++ b/src/renderer/components/SetupTab/ArgsForm/index.jsx
@@ -19,10 +19,11 @@ function dragOverHandler(event) {
 export default class ArgsForm extends React.Component {
   constructor(props) {
     super(props);
+    this.handleFocus = this.handleFocus.bind(this);
     this.handleChange = this.handleChange.bind(this);
-    this.inputDropHandler = this.inputDropHandler.bind(this);
     this.handleBoolChange = this.handleBoolChange.bind(this);
     this.selectFile = this.selectFile.bind(this);
+    this.inputDropHandler = this.inputDropHandler.bind(this);
     this.onArchiveDragDrop = this.onArchiveDragDrop.bind(this);
     this.dragEnterHandler = this.dragEnterHandler.bind(this);
     this.dragLeaveHandler = this.dragLeaveHandler.bind(this);
@@ -91,6 +92,11 @@ export default class ArgsForm extends React.Component {
     }
   }
 
+  handleFocus(event) {
+    const { name } = event.currentTarget;
+    this.props.updateArgTouched(name);
+  }
+
   handleChange(event) {
     /** Pass input value up to SetupTab for storage & validation. */
     const { name, value } = event.currentTarget;
@@ -145,6 +151,7 @@ export default class ArgsForm extends React.Component {
             isValid={argsValidation[argkey].valid}
             validationMessage={argsValidation[argkey].validationMessage}
             handleChange={this.handleChange}
+            handleFocus={this.handleFocus}
             inputDropHandler={this.inputDropHandler}
             handleBoolChange={this.handleBoolChange}
             selectFile={this.selectFile}

--- a/src/renderer/components/SetupTab/index.jsx
+++ b/src/renderer/components/SetupTab/index.jsx
@@ -76,6 +76,7 @@ export default class SetupTab extends React.Component {
   constructor(props) {
     super(props);
     this._isMounted = false;
+    this.validationTimer = null;
 
     this.state = {
       argsValues: null,
@@ -89,6 +90,8 @@ export default class SetupTab extends React.Component {
     this.saveJsonFile = this.saveJsonFile.bind(this);
     this.wrapInvestExecute = this.wrapInvestExecute.bind(this);
     this.investValidate = this.investValidate.bind(this);
+    this.debouncedValidate = this.debouncedValidate.bind(this);
+    this.updateArgTouched = this.updateArgTouched.bind(this);
     this.updateArgValues = this.updateArgValues.bind(this);
     this.batchUpdateArgs = this.batchUpdateArgs.bind(this);
     this.insertNWorkers = this.insertNWorkers.bind(this);
@@ -141,6 +144,7 @@ export default class SetupTab extends React.Component {
 
   componentWillUnmount() {
     this._isMounted = false;
+    clearTimeout(this.validationTimer);
   }
 
   /**
@@ -241,12 +245,30 @@ export default class SetupTab extends React.Component {
     this.props.investExecute(argsDictFromObject(argsValues));
   }
 
+  /** Update state to indicate that an input was touched.
+   *
+   * Validation messages only display on inputs that have been touched.
+   * Validation state is always displayed, but suppressing the message
+   * until an input is touched reduces noise & clutter on a default form.
+   *
+   * @param {string} key - the invest argument key
+   * @returns {undefined}
+   */
+  updateArgTouched(key) {
+    const { argsValues } = this.state;
+    if (!argsValues[key].touched) {
+      argsValues[key].touched = true;
+      this.setState({
+        argsValues: argsValues
+      });
+    }
+  }
+
   /** Update state with arg values as they change. And validate the args.
    *
    * Updating means:
    * 1) setting the value
-   * 2) 'touching' the arg - implications for display of validation warnings
-   * 3) toggling the enabled/disabled/hidden state of any dependent args
+   * 2) toggling the enabled/disabled/hidden state of any dependent args
    *
    * @param {string} key - the invest argument key
    * @param {string} value - the invest argument value
@@ -255,12 +277,10 @@ export default class SetupTab extends React.Component {
   updateArgValues(key, value) {
     const { argsValues } = this.state;
     argsValues[key].value = value;
-    argsValues[key].touched = true;
-
     this.setState({
       argsValues: argsValues
     }, () => {
-      this.investValidate();
+      this.debouncedValidate();
       this.callUISpecFunctions();
     });
   }
@@ -285,9 +305,25 @@ export default class SetupTab extends React.Component {
     });
   }
 
+  /** Get a debounced version of investValidate.
+   *
+   * The original validate function will not be called until after the
+   * debounced version stops being invoked for N milliseconds.
+   *
+   * @returns {undefined}
+   */
+  debouncedValidate() {
+    if (this.validationTimer) {
+      clearTimeout(this.validationTimer);
+    }
+    // we want validation to be very responsive,
+    // but also to wait for a pause in data entry.
+    this.validationTimer = setTimeout(this.investValidate, 200);
+  }
+
   /** Validate an arguments dictionary using the InVEST model's validate function.
    *
-   * @returns undefined
+   * @returns {undefined}
    */
   async investValidate() {
     const { argsSpec, pyModuleName } = this.props;
@@ -388,6 +424,7 @@ export default class SetupTab extends React.Component {
               argsDropdownOptions={argsDropdownOptions}
               argsOrder={uiSpec.order}
               updateArgValues={this.updateArgValues}
+              updateArgTouched={this.updateArgTouched}
               loadParametersFromFile={this.loadParametersFromFile}
             />
           </Row>


### PR DESCRIPTION
This fixes #144 and fixes #182 

It adds a `debouncedValidate` method to delay requests to invest validation until there is a pause in data entry. I set this at 200ms, which seems like a decent compromise between getting very responsive validation, but not validating too often as someone types or lays on the backspace key.

There's also a new method for handling focus on an input differently from handling changes to the input value.